### PR TITLE
force init of state of instance.mIsButtonOneDown at exception handler

### DIFF
--- a/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
@@ -162,6 +162,11 @@ public class InputService extends AccessibilityService {
 		} catch (Exception e) {
 			// instance probably null
 			Log.e(TAG, "onPointerEvent: failed: " + e.toString());
+                       
+                        // force init of state of onPointerEvent's instance.mIsButtonOneDown.
+                        if ( instance.mIsButtonOneDown == true ) {
+                            instance.mIsButtonOneDown = false;
+                        }
 		}
 	}
 


### PR DESCRIPTION
Hello, i'm a fan of your really useful work. I want to give a greate appreciation to your job first.
----------------------------------------------------------

this is a 'pull request' for simple solution of the problems that are guessed it rarely occurs in slow networks.
  
(at InputService.java)
Let's suppose a endGesture function was called(proccessed) with 7sec delay after startGesture because of any reason.

Fist Except would be occured at below line.
GestureDescription.StrokeDescription stroke = new GestureDescription.StrokeDescription( mPath, 0, System.currentTimeMillis() - mLastGestureStartTime);

It's because At the android accessibilityservice/GestureDescription.java, MAX_GESTURE_DURATION_MS was defined 6000ms.
and if getTotalDuration(mStrokes) is greater than MAX_GESTURE_DURATION_MS, 
Exception will be occured with "Gesture would exceed maximum duration with new stroke" this message.

Actually Exception was occured at endGesture function call, so "instance.mIsButtonOneDown = false" can't be proccessed.

And then instance.mIsButtonOneDown will be never update( in this case it's value is always true )
So instance.startGesture(x, y) is never update( actually means this line never be called )
It means mLastGestureStartTime can't be update forever.

and.. the value of 'System.currentTimeMillis() - mLastGestureStartTime' is grow up more and more.

Of course, this value is the more big than MAX_GESTURE_DURATION_MS forever, and all touch event after exception isn't deal with.

The more bad thing is this issue can't be solve with easy way like app force close or stop/start at pannel. 
for my case i did for solving this state normally , i had to clear app date or cache at least.
and in the worst case once i met, i had to remove app and re-install droidVNC.

I think your droidVNC-NG app need to be consider one of these 'force init when exception occured' 
 or 'background service clean restart' at least Or both of them.

Actually my 'pull request' has only 'force init state' and I hope you consider improving the structure or something.

thanks.

---
Reference 1. onPointerEvent function

        // up, was down
        if ((buttonMask & (1 << 0)) == 0 && instance.mIsButtonOneDown) {
            //instance.mIsButtonOneDown = false;
            instance.endGesture(x, y);
            instance.mIsButtonOneDown = false;
        }

---
Reference 2. startGesture
    private void startGesture(int x, int y) {
        mPath = new Path();
        mPath.moveTo( x, y );
        mLastGestureStartTime = System.currentTimeMillis();
    }

---
Reference 3. accessibilityservice/gesture code at android framework.

https://android.googlesource.com/platform/frameworks/base/+/5f256310187b4ff2f13a7abb9afed9126facd7bc/core/java/android/accessibilityservice/GestureDescription.java

private static final long MAX_GESTURE_DURATION_MS = 60 * 1000;

...

if (getTotalDuration(mStrokes) > MAX_GESTURE_DURATION_MS) {
                mStrokes.remove(strokeDescription);
                throw new IllegalStateException(
                        "Gesture would exceed maximum duration with new stroke");
}

...
//////////
