### PR TITLE
added UVNC Repeater support

### DIFF
--- a/app/src/main/cpp/droidvnc-ng.c
+++ b/app/src/main/cpp/droidvnc-ng.c
@@ -168,11 +168,6 @@ static enum rfbNewClientAction onClientConnected(rfbClientPtr cl)
     return RFB_CLIENT_ACCEPT;
 }
 
-static void clientGone(rfbClientPtr cl)
-{
-    __android_log_print(ANDROID_LOG_INFO, TAG, "Repeater connection closed.");
-}
-
 rfbClientPtr
 repeaterConnection(rfbScreenInfoPtr rfbScreen,
                    char *repeaterHost,
@@ -205,7 +200,6 @@ repeaterConnection(rfbScreenInfoPtr rfbScreen,
     }
 
     cl->reverseConnection = 0;
-    cl->clientGoneHook = clientGone;
     if (!cl->onHold)
         rfbStartOnHoldClient(cl);
     return cl;

--- a/app/src/main/cpp/droidvnc-ng.c
+++ b/app/src/main/cpp/droidvnc-ng.c
@@ -329,12 +329,13 @@ JNIEXPORT jboolean JNICALL Java_net_christianbeier_droidvnc_1ng_MainService_vncS
 
     rfbInitServer(theScreen);
 
-    if(theScreen->listenSock == RFB_INVALID_SOCKET || theScreen->listen6Sock == RFB_INVALID_SOCKET) {
-        __android_log_print(ANDROID_LOG_ERROR, TAG, "vncStartServer: failed starting (%s)", strerror(errno));
-        Java_net_christianbeier_droidvnc_1ng_MainService_vncStopServer(env, thiz);
-        return JNI_FALSE;
+    if (port != -1) {
+        if (theScreen->listenSock == RFB_INVALID_SOCKET || theScreen->listen6Sock == RFB_INVALID_SOCKET) {
+            __android_log_print(ANDROID_LOG_ERROR, TAG, "vncStartServer: failed starting (%s)", strerror(errno));
+            Java_net_christianbeier_droidvnc_1ng_MainService_vncStopServer(env, thiz);
+            return JNI_FALSE;
+        }
     }
-
     rfbRunEventLoop(theScreen, -1, TRUE);
 
     __android_log_print(ANDROID_LOG_INFO, TAG, "vncStartServer: successfully started");

--- a/app/src/main/cpp/droidvnc-ng.c
+++ b/app/src/main/cpp/droidvnc-ng.c
@@ -323,13 +323,12 @@ JNIEXPORT jboolean JNICALL Java_net_christianbeier_droidvnc_1ng_MainService_vncS
 
     rfbInitServer(theScreen);
 
-    if (port != -1) {
-        if (theScreen->listenSock == RFB_INVALID_SOCKET || theScreen->listen6Sock == RFB_INVALID_SOCKET) {
-            __android_log_print(ANDROID_LOG_ERROR, TAG, "vncStartServer: failed starting (%s)", strerror(errno));
-            Java_net_christianbeier_droidvnc_1ng_MainService_vncStopServer(env, thiz);
-            return JNI_FALSE;
-        }
+    if(theScreen->listenSock == RFB_INVALID_SOCKET || theScreen->listen6Sock == RFB_INVALID_SOCKET) {
+        __android_log_print(ANDROID_LOG_ERROR, TAG, "vncStartServer: failed starting (%s)", strerror(errno));
+        Java_net_christianbeier_droidvnc_1ng_MainService_vncStopServer(env, thiz);
+        return JNI_FALSE;
     }
+
     rfbRunEventLoop(theScreen, -1, TRUE);
 
     __android_log_print(ANDROID_LOG_INFO, TAG, "vncStartServer: successfully started");

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
@@ -25,11 +25,12 @@ public class Constants {
 
     public static final int DEFAULT_PORT = 5900;
     public static final int DEFAULT_PORT_REVERSE = 5500;
+    public static final int DEFAULT_PORT_REPEATER = 5500;
     public static final float DEFAULT_SCALING = 1.0f;
     public static final String PREFS_KEY_SETTINGS_PORT = "settings_port";
     public static final String PREFS_KEY_SETTINGS_PASSWORD = "settings_password" ;
     public static final String PREFS_KEY_SETTINGS_START_ON_BOOT = "settings_start_on_boot" ;
     public static final String PREFS_KEY_SETTINGS_SCALING = "settings_scaling" ;
     public static final String PREFS_KEY_REVERSE_VNC_LAST_HOST = "reverse_vnc_last_host" ;
-
+    public static final String PREFS_KEY_REPEATER_VNC_LAST_CONNECTION_STRING = "repeater_vnc_last_connection_string" ;
 }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -297,18 +297,8 @@ public class MainActivity extends AppCompatActivity {
                     if (i != hostsAndPorts.size() - 1)
                         sb.append(" ").append(getString(R.string.or)).append(" ");
                 }
-
-                int sPort = Constants.DEFAULT_PORT;
-                try {
-                    sPort = prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, Constants.DEFAULT_PORT);
-                } catch (NullPointerException e) {
-                    //unused
-                }
-                String message = (sPort == -1)
-                        ? getString(R.string.main_activity_no_listening)
-                        : getString(R.string.main_activity_address) + " " + sb;
                 mAddress.post(() -> {
-                    mAddress.setText(message);
+                    mAddress.setText(getString(R.string.main_activity_address) + " " + sb);
                 });
                 mButtonReverseVNC.post(() -> {
                     mButtonReverseVNC.setVisibility(View.VISIBLE);

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -297,8 +297,18 @@ public class MainActivity extends AppCompatActivity {
                     if (i != hostsAndPorts.size() - 1)
                         sb.append(" ").append(getString(R.string.or)).append(" ");
                 }
+
+                int sPort = Constants.DEFAULT_PORT;
+                try {
+                    sPort = prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, Constants.DEFAULT_PORT);
+                } catch (NullPointerException e) {
+                    //unused
+                }
+                String message = (sPort == -1)
+                        ? getString(R.string.main_activity_no_listening)
+                        : getString(R.string.main_activity_address) + " " + sb;
                 mAddress.post(() -> {
-                    mAddress.setText(getString(R.string.main_activity_address) + " " + sb);
+                    mAddress.setText(message);
                 });
                 mButtonReverseVNC.post(() -> {
                     mButtonReverseVNC.setVisibility(View.VISIBLE);

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -186,7 +186,7 @@ public class MainService extends Service {
 
         if (!vncStartServer(displayMetrics.widthPixels,
                 displayMetrics.heightPixels,
-                prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, 5900),
+                prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, Constants.DEFAULT_PORT),
                 Settings.Secure.getString(getContentResolver(), "bluetooth_name"),
                 prefs.getString(Constants.PREFS_KEY_SETTINGS_PASSWORD, "")))
             stopSelf();
@@ -491,11 +491,11 @@ public class MainService extends Service {
      */
     public static ArrayList<String> getIPv4sAndPorts() {
 
-        int port = 5900;
+        int port = Constants.DEFAULT_PORT;
 
         try {
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(instance);
-            port = prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, 5900);
+            port = prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, Constants.DEFAULT_PORT);
         } catch (NullPointerException e) {
             //unused
         }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -186,7 +186,7 @@ public class MainService extends Service {
 
         if (!vncStartServer(displayMetrics.widthPixels,
                 displayMetrics.heightPixels,
-                prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, Constants.DEFAULT_PORT),
+                prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, 5900),
                 Settings.Secure.getString(getContentResolver(), "bluetooth_name"),
                 prefs.getString(Constants.PREFS_KEY_SETTINGS_PASSWORD, "")))
             stopSelf();
@@ -491,11 +491,11 @@ public class MainService extends Service {
      */
     public static ArrayList<String> getIPv4sAndPorts() {
 
-        int port = Constants.DEFAULT_PORT;
+        int port = 5900;
 
         try {
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(instance);
-            port = prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, Constants.DEFAULT_PORT);
+            port = prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, 5900);
         } catch (NullPointerException e) {
             //unused
         }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -108,6 +108,7 @@ public class MainService extends Service {
     private native boolean vncStartServer(int width, int height, int port, String desktopname, String password);
     private native boolean vncStopServer();
     private native boolean vncConnectReverse(String host, int port);
+    private native boolean vncConnectRepeater(String host, int port, String repeaterIdentifier);
     private native boolean vncNewFramebuffer(int width, int height);
     private native boolean vncUpdateFramebuffer(ByteBuffer buf);
     private native int vncGetFramebufferWidth();
@@ -526,6 +527,15 @@ public class MainService extends Service {
     public static boolean connectReverse(String host, int port) {
         try {
             return instance.vncConnectReverse(host, port);
+        }
+        catch (NullPointerException e) {
+            return false;
+        }
+    }
+
+    public static boolean connectRepeater(String host, int port, String repeaterIdentifier) {
+        try {
+            return instance.vncConnectRepeater(host, port, repeaterIdentifier);
         }
         catch (NullPointerException e) {
             return false;

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -49,8 +49,8 @@
                     android:layout_column="2"
                     android:padding="10dp"
                     android:layout_weight="1"
-                    android:inputType="number"
-                    android:id="@+id/settings_port"/>
+                    android:inputType="numberSigned"
+                    android:id="@+id/settings_port" />
             </TableRow>
 
             <TableRow

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -268,6 +268,14 @@
             android:text="@string/main_activity_reverse_vnc_button"
             android:visibility="invisible"/>
 
+        <Button
+            android:id="@+id/repeater_vnc"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:text="@string/main_activity_repeater_vnc_button"
+            android:visibility="invisible" />
+
         <TextView
             android:id="@+id/special_key_reference"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -49,8 +49,8 @@
                     android:layout_column="2"
                     android:padding="10dp"
                     android:layout_weight="1"
-                    android:inputType="numberSigned"
-                    android:id="@+id/settings_port" />
+                    android:inputType="number"
+                    android:id="@+id/settings_port"/>
             </TableRow>
 
             <TableRow

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,6 @@
     <string name="main_activity_file_access">File Access</string>
     <string name="main_activity_input">Input</string>
     <string name="main_activity_address">The server is now reachable at</string>
-    <string name="main_activity_no_listening">The server is not accepting incoming connections</string>
     <string name="main_activity_reverse_vnc_button">Connect to a listening viewer</string>
     <string name="main_activity_reverse_vnc_hint">Host:Port</string>
     <string name="main_activity_reverse_vnc_success">Connection to %1$s:%2$d succeeded</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="main_activity_file_access">File Access</string>
     <string name="main_activity_input">Input</string>
     <string name="main_activity_address">The server is now reachable at</string>
+    <string name="main_activity_no_listening">The server is not accepting incoming connections</string>
     <string name="main_activity_reverse_vnc_button">Connect to a listening viewer</string>
     <string name="main_activity_reverse_vnc_hint">Host:Port</string>
     <string name="main_activity_reverse_vnc_success">Connection to %1$s:%2$d succeeded</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,11 @@
     <string name="main_activity_reverse_vnc_hint">Host:Port</string>
     <string name="main_activity_reverse_vnc_success">Connection to %1$s:%2$d succeeded</string>
     <string name="main_activity_reverse_vnc_fail">Connection to %1$s:%2$d failed</string>
+    <string name="main_activity_repeater_vnc_button">Connect to a viewer using a repeater</string>
+    <string name="main_activity_repeater_vnc_hint">Host:Port:Id</string>
+    <string name="main_activity_repeater_vnc_success">Connection to %1$s:%2$d:%3$s succeeded</string>
+    <string name="main_activity_repeater_vnc_fail">Connection to %1$s:%2$d:%3$s failed</string>
+    <string name="main_activity_invalid_input">Invalid input</string>
     <string name="main_activity_special_key_reference">From a VNC viewer, <b>Ctrl-Shift-Esc</b> triggers \'Recent Apps\' overview, <b>Home/Pos1</b> acts as Home button, <b>Escape</b> acts as Back button.</string>
     <string name="main_activity_about">This is droidVNC-NG %1$s. Please note that more features are still being added to droidVNC-NG. In particular, most keyboard strokes as of now can only be input via the Android soft keyboard, there is only limited support for keyboard events from VNC viewers (yet). Please report any issues and feature requests at https://github.com/bk138/droidVNC-NG</string>
     <string name="start">Start</string>


### PR DESCRIPTION
When applied, this commit will allow to create a UVNC repeater connection MODE 2 (https://uvnc.com/products/uvnc-repeater.html). Entering a -1 in the port field allows us to start the VNC server without accepting incoming connections, while being able to create outgoing connections
- 