### PR TITLE
Intent interface for MainService

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,84 @@ An example `defaults.json` with completely new defaults (not all entries need to
 }
 ```
 
+### Remote Control via the Intent Interface
+
+droidVNC-NG features a remote control interface by means of Intents. This allows starting the VNC
+server from other apps or on certain events. It is designed to be working with automation apps
+like [MacroDroid](https://www.macrodroid.com/), [Automate](https://llamalab.com/automate/) or
+[Tasker](https://tasker.joaoapps.com/) as well as to be called from code.
+
+You basically send an explicit Intent to `net.christianbeier.droidvnc_ng.MainService` with one of
+the following Actions and associated Extras set:
+
+* `net.christianbeier.droidvnc_ng.ACTION_START`: Starts the server.
+  * `net.christianbeier.droidvnc_ng.EXTRA_ACCESS_KEY`: Required String Extra containing the remote control interface's access key. You can get/set this from the Admin Panel. 
+  * `net.christianbeier.droidvnc_ng.EXTRA_REQUEST_ID`: Optional String Extra containing a unique id for this request. Used to identify the answer from the service.
+  * `net.christianbeier.droidvnc_ng.EXTRA_PORT`: Optional Integer Extra setting the listening port. Set to `-1` to disable listening.
+  * `net.christianbeier.droidvnc_ng.EXTRA_PASSWORD`: Optional String Extra containing VNC password.
+  * `net.christianbeier.droidvnc_ng.EXTRA_SCALING`: Optional Float Extra between 0.0 and 1.0 describing the server-side framebuffer scaling.
+  * `net.christianbeier.droidvnc_ng.EXTRA_VIEW_ONLY`:  Optional Boolean Extra toggling view-only mode.
+  * `net.christianbeier.droidvnc_ng.EXTRA_FILE_TRANSFER`: Optional Boolean Extra toggling the file transfer feature.
+
+* `net.christianbeier.droidvnc_ng.ACTION_CONNECT_REVERSE`: Make an outbound connection to a listening viewer.
+  * `net.christianbeier.droidvnc_ng.EXTRA_ACCESS_KEY`: Required String Extra containing the remote control interface's access key. You can get/set this from the Admin Panel.
+  * `net.christianbeier.droidvnc_ng.EXTRA_REQUEST_ID`: Optional String Extra containing a unique id for this request. Used to identify the answer from the service.
+  * `net.christianbeier.droidvnc_ng.EXTRA_HOST`: Required String Extra setting the host to connect to.
+  * `net.christianbeier.droidvnc_ng.EXTRA_PORT`: Optional Integer Extra setting the remote port.
+
+* `net.christianbeier.droidvnc_ng.ACTION_CONNECT_REPEATER` Make an outbound connection to a repeater.
+  * `net.christianbeier.droidvnc_ng.EXTRA_ACCESS_KEY`: Required String Extra containing the remote control interface's access key. You can get/set this from the Admin Panel.
+  * `net.christianbeier.droidvnc_ng.EXTRA_REQUEST_ID`: Optional String Extra containing a unique id for this request. Used to identify the answer from the service.
+  * `net.christianbeier.droidvnc_ng.EXTRA_HOST`: Required String Extra setting the host to connect to.
+  * `net.christianbeier.droidvnc_ng.EXTRA_PORT`: Optional Integer Extra setting the remote port.
+  * `net.christianbeier.droidvnc_ng.EXTRA_REPEATER_ID`: Required String Extra setting the ID on the repeater.
+
+* `net.christianbeier.droidvnc_ng.ACTION_STOP`: Stops the server.
+  * `net.christianbeier.droidvnc_ng.EXTRA_ACCESS_KEY`: Required String Extra containing the remote control interface's access key. You can get/set this from the Admin Panel.
+  * `net.christianbeier.droidvnc_ng.EXTRA_REQUEST_ID`: Optional String Extra containing a unique id for this request. Used to identify the answer from the service.
+
+The service answers with a Broadcast Intent with its Action mirroring your request:
+
+* Action: one of the above Actions you requested
+  * `net.christianbeier.droidvnc_ng.EXTRA_REQUEST_ID`: The request id this answer is for.
+  * `net.christianbeier.droidvnc_ng.EXTRA_REQUEST_SUCCESS`: Boolean Extra describing the outcome of the request.
+
+#### Examples
+
+##### Start a password-protected view-only server on port 5901
+
+Using `adb shell am` syntax:
+
+```shell
+adb shell am start-foreground-service \
+ -n net.christianbeier.droidvnc_ng/.MainService \
+ -a net.christianbeier.droidvnc_ng.ACTION_START \
+ --es net.christianbeier.droidvnc_ng.EXTRA_ACCESS_KEY de32550a6efb43f8a5d145e6c07b2cde \
+ --es net.christianbeier.droidvnc_ng.EXTRA_REQUEST_ID abc123 \
+ --ei net.christianbeier.droidvnc_ng.EXTRA_PORT 5901 \
+ --es net.christianbeier.droidvnc_ng.EXTRA_PASSWORD supersecure \
+ --ez net.christianbeier.droidvnc_ng.EXTRA_VIEW_ONLY true
+```
+
+##### Make an outbound connection to a listening viewer from the running server
+
+For example from Java code:
+
+See [MainActivity.java](app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java).
+
+##### Stop the server again
+
+Using `adb shell am` syntax again:
+
+```shell
+adb shell am start-foreground-service \
+ -n net.christianbeier.droidvnc_ng/.MainService \
+ -a net.christianbeier.droidvnc_ng.ACTION_STOP \
+ --es net.christianbeier.droidvnc_ng.EXTRA_ACCESS_KEY de32550a6efb43f8a5d145e6c07b2cde \
+ --es net.christianbeier.droidvnc_ng.EXTRA_REQUEST_ID def456
+```
+
+
 ## Notes
 
 * Requires at least Android 7.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ An example `defaults.json` with completely new defaults (not all entries need to
     "portReverse": 5555,
     "portRepeater": 5556,
     "scaling": 0.7,
+    "viewOnly": false,
     "password": "supersecure",
     "accessKey": "evenmoresecure"
 }

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ An example `defaults.json` with completely new defaults (not all entries need to
     "portReverse": 5555,
     "portRepeater": 5556,
     "scaling": 0.7,
-    "password": "supersecure"
+    "password": "supersecure",
+    "accessKey": "evenmoresecure"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ An example `defaults.json` with completely new defaults (not all entries need to
     "portRepeater": 5556,
     "scaling": 0.7,
     "viewOnly": false,
+    "fileTranfer": true,
     "password": "supersecure",
     "accessKey": "evenmoresecure"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,9 +23,16 @@
             </intent-filter>
         </receiver>
 
+        <!--
+            We export the MainService without a permission to enable 3rd party apps to send
+            send Intents to it (otherwise they would have to know about the permission at build
+            time). Access is secured differently by an access key Intent senders have to supply.
+            As only explicit Intents are handled (i.e. no intent-filter), this is secure.
+        -->
         <service
             android:name=".MainService"
             android:enabled="true"
+            android:exported="true"
             android:foregroundServiceType="mediaProjection" />
 
         <service

--- a/app/src/main/cpp/droidvnc-ng.c
+++ b/app/src/main/cpp/droidvnc-ng.c
@@ -461,3 +461,7 @@ JNIEXPORT jint JNICALL Java_net_christianbeier_droidvnc_1ng_MainService_vncGetFr
 
     return theScreen->height;
 }
+
+JNIEXPORT jboolean JNICALL Java_net_christianbeier_droidvnc_1ng_MainService_vncIsActive(JNIEnv *env, jobject thiz) {
+    return theScreen && rfbIsActive(theScreen);
+}

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
@@ -29,6 +29,7 @@ public class Constants {
     public static final String PREFS_KEY_SETTINGS_PASSWORD = "settings_password" ;
     public static final String PREFS_KEY_SETTINGS_START_ON_BOOT = "settings_start_on_boot" ;
     public static final String PREFS_KEY_SETTINGS_SCALING = "settings_scaling" ;
+    public static final String PREFS_KEY_SETTINGS_VIEW_ONLY = "settings_view_only" ;
     public static final String PREFS_KEY_SETTINGS_ACCESS_KEY = "settings_access_key";
     /*
         persisted generated defaults

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
@@ -43,4 +43,6 @@ public class Constants {
     public static final String PREFS_KEY_REPEATER_VNC_LAST_ID = "repeater_vnc_last_id" ;
     public static final String PREFS_KEY_SERVER_LAST_PORT = "server_last_port" ;
     public static final String PREFS_KEY_SERVER_LAST_PASSWORD = "server_last_password" ;
+    public static final String PREFS_KEY_SERVER_LAST_SCALING = "server_last_scaling" ;
+    public static final String PREFS_KEY_INPUT_LAST_ENABLED = "input_last_enabled" ;
 }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
@@ -34,12 +34,8 @@ public class Constants {
     public static final String PREFS_KEY_SETTINGS_FILE_TRANSFER = "settings_file_transfer";
 
     /*
-        persisted runtime values
+        persisted runtime values shared between components
      */
-    public static final String PREFS_KEY_SERVER_LAST_PORT = "server_last_port" ;
-    public static final String PREFS_KEY_SERVER_LAST_PASSWORD = "server_last_password" ;
     public static final String PREFS_KEY_SERVER_LAST_SCALING = "server_last_scaling" ;
-    public static final String PREFS_KEY_SERVER_LAST_FILE_TRANSFER = "server_last_file_transfer" ;
-    public static final String PREFS_KEY_SERVER_LAST_START_REQUEST_ID = "server_last_start_request_id" ;
     public static final String PREFS_KEY_INPUT_LAST_ENABLED = "input_last_enabled" ;
 }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
@@ -31,6 +31,8 @@ public class Constants {
     public static final String PREFS_KEY_SETTINGS_SCALING = "settings_scaling" ;
     public static final String PREFS_KEY_SETTINGS_VIEW_ONLY = "settings_view_only" ;
     public static final String PREFS_KEY_SETTINGS_ACCESS_KEY = "settings_access_key";
+    public static final String PREFS_KEY_SETTINGS_FILE_TRANSFER = "settings_file_transfer";
+
     /*
         persisted generated defaults
      */
@@ -44,5 +46,6 @@ public class Constants {
     public static final String PREFS_KEY_SERVER_LAST_PORT = "server_last_port" ;
     public static final String PREFS_KEY_SERVER_LAST_PASSWORD = "server_last_password" ;
     public static final String PREFS_KEY_SERVER_LAST_SCALING = "server_last_scaling" ;
+    public static final String PREFS_KEY_SERVER_LAST_FILE_TRANSFER = "server_last_file_transfer" ;
     public static final String PREFS_KEY_INPUT_LAST_ENABLED = "input_last_enabled" ;
 }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
@@ -47,5 +47,6 @@ public class Constants {
     public static final String PREFS_KEY_SERVER_LAST_PASSWORD = "server_last_password" ;
     public static final String PREFS_KEY_SERVER_LAST_SCALING = "server_last_scaling" ;
     public static final String PREFS_KEY_SERVER_LAST_FILE_TRANSFER = "server_last_file_transfer" ;
+    public static final String PREFS_KEY_SERVER_LAST_START_REQUEST_ID = "server_last_start_request_id" ;
     public static final String PREFS_KEY_INPUT_LAST_ENABLED = "input_last_enabled" ;
 }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
@@ -22,10 +22,21 @@
 package net.christianbeier.droidvnc_ng;
 
 public class Constants {
+    /*
+        user settings
+     */
     public static final String PREFS_KEY_SETTINGS_PORT = "settings_port";
     public static final String PREFS_KEY_SETTINGS_PASSWORD = "settings_password" ;
     public static final String PREFS_KEY_SETTINGS_START_ON_BOOT = "settings_start_on_boot" ;
     public static final String PREFS_KEY_SETTINGS_SCALING = "settings_scaling" ;
+    public static final String PREFS_KEY_SETTINGS_ACCESS_KEY = "settings_access_key";
+    /*
+        persisted generated defaults
+     */
+    public static final String PREFS_KEY_DEFAULTS_ACCESS_KEY = "defaults_access_key";
+    /*
+        persisted ui values
+     */
     public static final String PREFS_KEY_REVERSE_VNC_LAST_HOST = "reverse_vnc_last_host" ;
     public static final String PREFS_KEY_REPEATER_VNC_LAST_HOST = "repeater_vnc_last_host" ;
     public static final String PREFS_KEY_REPEATER_VNC_LAST_ID = "repeater_vnc_last_id" ;

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
@@ -34,10 +34,6 @@ public class Constants {
     public static final String PREFS_KEY_SETTINGS_FILE_TRANSFER = "settings_file_transfer";
 
     /*
-        persisted generated defaults
-     */
-    public static final String PREFS_KEY_DEFAULTS_ACCESS_KEY = "defaults_access_key";
-    /*
         persisted runtime values
      */
     public static final String PREFS_KEY_REVERSE_VNC_LAST_HOST = "reverse_vnc_last_host" ;

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
@@ -36,9 +36,11 @@ public class Constants {
      */
     public static final String PREFS_KEY_DEFAULTS_ACCESS_KEY = "defaults_access_key";
     /*
-        persisted ui values
+        persisted runtime values
      */
     public static final String PREFS_KEY_REVERSE_VNC_LAST_HOST = "reverse_vnc_last_host" ;
     public static final String PREFS_KEY_REPEATER_VNC_LAST_HOST = "repeater_vnc_last_host" ;
     public static final String PREFS_KEY_REPEATER_VNC_LAST_ID = "repeater_vnc_last_id" ;
+    public static final String PREFS_KEY_SERVER_LAST_PORT = "server_last_port" ;
+    public static final String PREFS_KEY_SERVER_LAST_PASSWORD = "server_last_password" ;
 }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
@@ -36,9 +36,6 @@ public class Constants {
     /*
         persisted runtime values
      */
-    public static final String PREFS_KEY_REVERSE_VNC_LAST_HOST = "reverse_vnc_last_host" ;
-    public static final String PREFS_KEY_REPEATER_VNC_LAST_HOST = "repeater_vnc_last_host" ;
-    public static final String PREFS_KEY_REPEATER_VNC_LAST_ID = "repeater_vnc_last_id" ;
     public static final String PREFS_KEY_SERVER_LAST_PORT = "server_last_port" ;
     public static final String PREFS_KEY_SERVER_LAST_PASSWORD = "server_last_password" ;
     public static final String PREFS_KEY_SERVER_LAST_SCALING = "server_last_scaling" ;

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Defaults.kt
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Defaults.kt
@@ -59,6 +59,10 @@ class Defaults {
         private set
 
     @EncodeDefault
+    var fileTranfer = false
+        private set
+
+    @EncodeDefault
     var password = ""
         private set
 
@@ -95,6 +99,7 @@ class Defaults {
             this.port = readDefault.port
             this.portReverse = readDefault.portReverse
             this.portRepeater = readDefault.portRepeater
+            this.fileTranfer = readDefault.fileTranfer
             this.scaling = readDefault.scaling
             this.viewOnly = readDefault.viewOnly
             this.password = readDefault.password

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Defaults.kt
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Defaults.kt
@@ -36,6 +36,7 @@ import java.util.UUID
 class Defaults {
     companion object {
         private const val TAG = "Defaults"
+        private const val PREFS_KEY_DEFAULTS_ACCESS_KEY = "defaults_access_key"
     }
 
     @EncodeDefault
@@ -78,16 +79,16 @@ class Defaults {
             persist randomly generated defaults
          */
         val prefs = PreferenceManager.getDefaultSharedPreferences(context)
-        val defaultAccessKey = prefs.getString(Constants.PREFS_KEY_DEFAULTS_ACCESS_KEY, null)
+        val defaultAccessKey = prefs.getString(PREFS_KEY_DEFAULTS_ACCESS_KEY, null)
         if (defaultAccessKey == null) {
             val ed: SharedPreferences.Editor = prefs.edit()
             ed.putString(
-                Constants.PREFS_KEY_DEFAULTS_ACCESS_KEY,
+                PREFS_KEY_DEFAULTS_ACCESS_KEY,
                 UUID.randomUUID().toString().replace("-".toRegex(), "")
             )
             ed.apply()
         }
-        this.accessKey = prefs.getString(Constants.PREFS_KEY_DEFAULTS_ACCESS_KEY, null)!!
+        this.accessKey = prefs.getString(PREFS_KEY_DEFAULTS_ACCESS_KEY, null)!!
 
         /*
             read provided defaults

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Defaults.kt
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Defaults.kt
@@ -55,6 +55,10 @@ class Defaults {
         private set
 
     @EncodeDefault
+    var viewOnly = false
+        private set
+
+    @EncodeDefault
     var password = ""
         private set
 
@@ -92,6 +96,7 @@ class Defaults {
             this.portReverse = readDefault.portReverse
             this.portRepeater = readDefault.portRepeater
             this.scaling = readDefault.scaling
+            this.viewOnly = readDefault.viewOnly
             this.password = readDefault.password
             this.accessKey = readDefault.accessKey
             // add here!

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Defaults.kt
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Defaults.kt
@@ -60,7 +60,7 @@ class Defaults {
         private set
 
     @EncodeDefault
-    var fileTranfer = false
+    var fileTranfer = true
         private set
 
     @EncodeDefault

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/InputRequestActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/InputRequestActivity.java
@@ -28,6 +28,7 @@ import android.provider.Settings;
 import android.util.Log;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.preference.PreferenceManager;
 
 public class InputRequestActivity extends AppCompatActivity {
 
@@ -81,6 +82,7 @@ public class InputRequestActivity extends AppCompatActivity {
         Intent intent = new Intent(this, MainService.class);
         intent.setAction(MainService.ACTION_HANDLE_INPUT_RESULT);
         intent.putExtra(MainService.EXTRA_INPUT_RESULT, isA11yEnabled);
+        intent.putExtra(MainService.EXTRA_ACCESS_KEY, PreferenceManager.getDefaultSharedPreferences(this).getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, new Defaults(this).getAccessKey()));
         startService(intent);
         finish();
     }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/InputRequestActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/InputRequestActivity.java
@@ -40,7 +40,7 @@ public class InputRequestActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if(!InputService.isEnabled()) {
+        if(!InputService.isConnected()) {
             new AlertDialog.Builder(this)
                     .setCancelable(false)
                     .setTitle(R.string.input_a11y_title)
@@ -68,7 +68,7 @@ public class InputRequestActivity extends AppCompatActivity {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == REQUEST_INPUT) {
             Log.d(TAG, "onActivityResult");
-            postResultAndFinish(InputService.isEnabled());
+            postResultAndFinish(InputService.isConnected());
         }
     }
 

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/InputRequestActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/InputRequestActivity.java
@@ -40,6 +40,12 @@ public class InputRequestActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        // if VIEW_ONLY is set, bail out early without bothering the user
+        if(getIntent().getBooleanExtra(MainService.EXTRA_VIEW_ONLY, new Defaults(this).getViewOnly())) {
+            postResultAndFinish(false);
+            return;
+        }
+
         if(!InputService.isConnected()) {
             new AlertDialog.Builder(this)
                     .setCancelable(false)

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
@@ -92,7 +92,7 @@ public class InputService extends AccessibilityService {
 		Log.i(TAG, "onDestroy");
 	}
 
-	public static boolean isEnabled()
+	public static boolean isConnected()
 	{
 		return instance != null;
 	}

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
@@ -51,6 +51,7 @@ public class InputService extends AccessibilityService {
 	private static final String TAG = "InputService";
 
 	private static InputService instance;
+	static boolean isEnabled;
 
 	private Handler mMainHandler;
 
@@ -115,6 +116,10 @@ public class InputService extends AccessibilityService {
 	@SuppressWarnings("unused")
 	public static void onPointerEvent(int buttonMask, int x, int y, long client) {
 
+		if(!isEnabled) {
+			return;
+		}
+
 		try {
 			x /= instance.mScaling;
 			y /= instance.mScaling;
@@ -172,6 +177,11 @@ public class InputService extends AccessibilityService {
 	}
 
 	public static void onKeyEvent(int down, long keysym, long client) {
+
+		if(!isEnabled) {
+			return;
+		}
+
 		Log.d(TAG, "onKeyEvent: keysym " + keysym + " down " + down + " by client " + client);
 
 		/*
@@ -235,6 +245,11 @@ public class InputService extends AccessibilityService {
 	}
 
 	public static void onCutText(String text, long client) {
+
+		if(!isEnabled) {
+			return;
+		}
+
 		Log.d(TAG, "onCutText: text '" + text + "' by client " + client);
 
 		try {

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
@@ -51,6 +51,11 @@ public class InputService extends AccessibilityService {
 	private static final String TAG = "InputService";
 
 	private static InputService instance;
+	/**
+        * Scaling factor that's applied to incoming pointer events by dividing coordinates by
+        * the given factor.
+        */
+	static float scaling;
 	static boolean isEnabled;
 
 	private Handler mMainHandler;
@@ -65,7 +70,6 @@ public class InputService extends AccessibilityService {
 	private boolean mIsKeyDelDown;
 	private boolean mIsKeyEscDown;
 
-	private float mScaling;
 
 	private final GestureCallback mGestureCallback = new GestureCallback();
 
@@ -81,8 +85,9 @@ public class InputService extends AccessibilityService {
 	{
 		super.onServiceConnected();
 		instance = this;
+		isEnabled = PreferenceManager.getDefaultSharedPreferences(this).getBoolean(Constants.PREFS_KEY_INPUT_LAST_ENABLED, !new Defaults(this).getViewOnly());
+		scaling = PreferenceManager.getDefaultSharedPreferences(this).getFloat(Constants.PREFS_KEY_SERVER_LAST_SCALING, new Defaults(this).getScaling());
 		mMainHandler = new Handler(instance.getMainLooper());
-		mScaling = PreferenceManager.getDefaultSharedPreferences(this).getFloat(Constants.PREFS_KEY_SETTINGS_SCALING, new Defaults(this).getScaling());
 		Log.i(TAG, "onServiceConnected");
 	}
 
@@ -98,20 +103,6 @@ public class InputService extends AccessibilityService {
 		return instance != null;
 	}
 
-	/**
-	 * Set scaling factor that's applied to incoming pointer events by dividing coordinates by
-	 * the given factor.
-	 * @param scaling The scaling factor as a real number.
-	 * @return Whether scaling was applied or not.
-	 */
-	public static boolean setScaling(float scaling) {
-		try {
-			instance.mScaling = scaling;
-			return true;
-		} catch (Exception e) {
-			return false;
-		}
-	}
 
 	@SuppressWarnings("unused")
 	public static void onPointerEvent(int buttonMask, int x, int y, long client) {
@@ -121,8 +112,8 @@ public class InputService extends AccessibilityService {
 		}
 
 		try {
-			x /= instance.mScaling;
-			y /= instance.mScaling;
+			x /= scaling;
+			y /= scaling;
 
 			/*
 			    left mouse button

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -33,6 +33,8 @@ import androidx.preference.PreferenceManager;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
+import android.text.method.PasswordTransformationMethod;
+import android.text.method.SingleLineTransformationMethod;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
@@ -259,15 +261,29 @@ public class MainActivity extends AppCompatActivity {
 
             @Override
             public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-                SharedPreferences.Editor ed = prefs.edit();
-                ed.putString(Constants.PREFS_KEY_SETTINGS_PASSWORD, charSequence.toString());
-                ed.apply();
+                // only save new value if it differs from the default
+                if(!charSequence.toString().equals(mDefaults.getPassword())) {
+                    SharedPreferences.Editor ed = prefs.edit();
+                    ed.putString(Constants.PREFS_KEY_SETTINGS_PASSWORD, charSequence.toString());
+                    ed.apply();
+                }
             }
 
             @Override
             public void afterTextChanged(Editable editable) {
 
             }
+        });
+        // show/hide password on focus change. NB that this triggers onTextChanged above, so we have
+        // to take special precautions there.
+        password.setOnFocusChangeListener((v, hasFocus) -> {
+            if (hasFocus) {
+                password.setTransformationMethod(new SingleLineTransformationMethod());
+            } else {
+                password.setTransformationMethod(new PasswordTransformationMethod());
+            }
+            // move cursor to end of text
+            password.setSelection(password.getText().length());
         });
 
         final SwitchMaterial startOnBoot = findViewById(R.id.settings_start_on_boot);

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -88,6 +88,7 @@ public class MainActivity extends AppCompatActivity {
             Intent intent = new Intent(MainActivity.this, MainService.class);
             intent.putExtra(MainService.EXTRA_PORT, prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, mDefaults.getPort()));
             intent.putExtra(MainService.EXTRA_PASSWORD, prefs.getString(Constants.PREFS_KEY_SETTINGS_PASSWORD, mDefaults.getPassword()));
+            intent.putExtra(MainService.EXTRA_FILE_TRANSFER, prefs.getBoolean(Constants.PREFS_KEY_SETTINGS_FILE_TRANSFER, mDefaults.getFileTranfer()));
             intent.putExtra(MainService.EXTRA_VIEW_ONLY, prefs.getBoolean(Constants.PREFS_KEY_SETTINGS_VIEW_ONLY, mDefaults.getViewOnly()));
             intent.putExtra(MainService.EXTRA_SCALING, prefs.getFloat(Constants.PREFS_KEY_SETTINGS_SCALING, mDefaults.getScaling()));
             intent.putExtra(MainService.EXTRA_ACCESS_KEY, prefs.getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, mDefaults.getAccessKey()));
@@ -343,6 +344,14 @@ public class MainActivity extends AppCompatActivity {
             ed.apply();
         });
 
+        final SwitchMaterial fileTransfer = findViewById(R.id.settings_file_transfer);
+        fileTransfer.setChecked(prefs.getBoolean(Constants.PREFS_KEY_SETTINGS_FILE_TRANSFER, mDefaults.getFileTranfer()));
+        fileTransfer.setOnCheckedChangeListener((compoundButton, b) -> {
+            SharedPreferences.Editor ed = prefs.edit();
+            ed.putBoolean(Constants.PREFS_KEY_SETTINGS_FILE_TRANSFER, b);
+            ed.apply();
+        });
+
         Slider scaling = findViewById(R.id.settings_scaling);
         scaling.setValue(prefs.getFloat(Constants.PREFS_KEY_SETTINGS_SCALING, mDefaults.getScaling())*100);
         scaling.setLabelFormatter(value -> Math.round(value) + " %");
@@ -394,6 +403,7 @@ public class MainActivity extends AppCompatActivity {
                 findViewById(R.id.settings_access_key).setEnabled(false);
                 findViewById(R.id.settings_scaling).setEnabled(false);
                 findViewById(R.id.settings_view_only).setEnabled(false);
+                findViewById(R.id.settings_file_transfer).setEnabled(false);
 
                 mIsMainServiceRunning = true;
             }
@@ -418,6 +428,8 @@ public class MainActivity extends AppCompatActivity {
                 findViewById(R.id.settings_access_key).setEnabled(true);
                 findViewById(R.id.settings_scaling).setEnabled(true);
                 findViewById(R.id.settings_view_only).setEnabled(true);
+                findViewById(R.id.settings_file_transfer).setEnabled(true);
+
 
                 mIsMainServiceRunning = false;
             }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -258,11 +258,11 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void afterTextChanged(Editable editable) {
                 if(port.getText().length() == 0) {
-                    // hint that default is set
-                    port.setHint(String.valueOf(mDefaults.getPort()));
+                    // hint that not listening
+                    port.setHint(R.string.main_activity_settings_port_not_listening);
                     // and set default
                     SharedPreferences.Editor ed = prefs.edit();
-                    ed.putInt(Constants.PREFS_KEY_SETTINGS_PORT, mDefaults.getPort());
+                    ed.putInt(Constants.PREFS_KEY_SETTINGS_PORT, -1);
                     ed.apply();
                 }
             }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -88,6 +88,7 @@ public class MainActivity extends AppCompatActivity {
             Intent intent = new Intent(MainActivity.this, MainService.class);
             intent.putExtra(MainService.EXTRA_PORT, prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, mDefaults.getPort()));
             intent.putExtra(MainService.EXTRA_PASSWORD, prefs.getString(Constants.PREFS_KEY_SETTINGS_PASSWORD, mDefaults.getPassword()));
+            intent.putExtra(MainService.EXTRA_VIEW_ONLY, prefs.getBoolean(Constants.PREFS_KEY_SETTINGS_VIEW_ONLY, mDefaults.getViewOnly()));
             intent.putExtra(MainService.EXTRA_ACCESS_KEY, prefs.getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, mDefaults.getAccessKey()));
             if(mIsMainServiceRunning) {
                 intent.setAction(MainService.ACTION_STOP);
@@ -350,6 +351,14 @@ public class MainActivity extends AppCompatActivity {
             ed.apply();
         });
 
+        final SwitchMaterial viewOnly = findViewById(R.id.settings_view_only);
+        viewOnly.setChecked(prefs.getBoolean(Constants.PREFS_KEY_SETTINGS_VIEW_ONLY, mDefaults.getViewOnly()));
+        viewOnly.setOnCheckedChangeListener((compoundButton, b) -> {
+            SharedPreferences.Editor ed = prefs.edit();
+            ed.putBoolean(Constants.PREFS_KEY_SETTINGS_VIEW_ONLY, b);
+            ed.apply();
+        });
+
         TextView about = findViewById(R.id.about);
         about.setText(getString(R.string.main_activity_about, BuildConfig.VERSION_NAME));
 
@@ -383,6 +392,7 @@ public class MainActivity extends AppCompatActivity {
                 findViewById(R.id.settings_password).setEnabled(false);
                 findViewById(R.id.settings_access_key).setEnabled(false);
                 findViewById(R.id.settings_scaling).setEnabled(false);
+                findViewById(R.id.settings_view_only).setEnabled(false);
 
                 mIsMainServiceRunning = true;
             }
@@ -406,6 +416,7 @@ public class MainActivity extends AppCompatActivity {
                 findViewById(R.id.settings_password).setEnabled(true);
                 findViewById(R.id.settings_access_key).setEnabled(true);
                 findViewById(R.id.settings_scaling).setEnabled(true);
+                findViewById(R.id.settings_view_only).setEnabled(true);
 
                 mIsMainServiceRunning = false;
             }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -62,6 +62,9 @@ import io.reactivex.rxjava3.disposables.Disposable;
 public class MainActivity extends AppCompatActivity {
 
     private static final String TAG = "MainActivity";
+    private static final String PREFS_KEY_REVERSE_VNC_LAST_HOST = "reverse_vnc_last_host" ;
+    private static final String PREFS_KEY_REPEATER_VNC_LAST_HOST = "repeater_vnc_last_host" ;
+    private static final String PREFS_KEY_REPEATER_VNC_LAST_ID = "repeater_vnc_last_id" ;
 
     private Button mButtonToggle;
     private Button mButtonReverseVNC;
@@ -121,7 +124,7 @@ public class MainActivity extends AppCompatActivity {
             final EditText inputText = new EditText(this);
             inputText.setInputType(InputType.TYPE_CLASS_TEXT);
             inputText.setHint(getString(R.string.main_activity_reverse_vnc_hint));
-            String lastHost = prefs.getString(Constants.PREFS_KEY_REVERSE_VNC_LAST_HOST, null);
+            String lastHost = prefs.getString(PREFS_KEY_REVERSE_VNC_LAST_HOST, null);
             if(lastHost != null) {
                 inputText.setText(lastHost);
                 // select all to make new input quicker
@@ -181,7 +184,7 @@ public class MainActivity extends AppCompatActivity {
             final EditText hostInputText = new EditText(this);
             hostInputText.setInputType(InputType.TYPE_CLASS_TEXT);
             hostInputText.setHint(getString(R.string.main_activity_repeater_vnc_hint));
-            String lastHost = prefs.getString(Constants.PREFS_KEY_REPEATER_VNC_LAST_HOST, "");
+            String lastHost = prefs.getString(PREFS_KEY_REPEATER_VNC_LAST_HOST, "");
             hostInputText.setText(lastHost); //host:port
             hostInputText.requestFocus();
             hostInputText.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
@@ -189,7 +192,7 @@ public class MainActivity extends AppCompatActivity {
             final EditText idInputText = new EditText(this);
             idInputText.setInputType(InputType.TYPE_CLASS_NUMBER);
             idInputText.setHint(getString(R.string.main_activity_repeater_vnc_hint_id));
-            String lastID = prefs.getString(Constants.PREFS_KEY_REPEATER_VNC_LAST_ID, "");
+            String lastID = prefs.getString(PREFS_KEY_REPEATER_VNC_LAST_ID, "");
             idInputText.setText(lastID); //host:port
             idInputText.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
 
@@ -469,7 +472,7 @@ public class MainActivity extends AppCompatActivity {
                                         Toast.LENGTH_LONG)
                                 .show();
                         SharedPreferences.Editor ed = prefs.edit();
-                        ed.putString(Constants.PREFS_KEY_REVERSE_VNC_LAST_HOST,
+                        ed.putString(PREFS_KEY_REVERSE_VNC_LAST_HOST,
                                 mLastReverseHost + ":" + mLastReversePort);
                         ed.apply();
                     } else
@@ -497,9 +500,9 @@ public class MainActivity extends AppCompatActivity {
                                         Toast.LENGTH_LONG)
                                 .show();
                         SharedPreferences.Editor ed = prefs.edit();
-                        ed.putString(Constants.PREFS_KEY_REPEATER_VNC_LAST_HOST,
+                        ed.putString(PREFS_KEY_REPEATER_VNC_LAST_HOST,
                                 mLastRepeaterHost + ":" + mLastRepeaterPort);
-                        ed.putString(Constants.PREFS_KEY_REPEATER_VNC_LAST_ID,
+                        ed.putString(PREFS_KEY_REPEATER_VNC_LAST_ID,
                                 mLastRepeaterId);
                         ed.apply();
                     }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -458,7 +458,7 @@ public class MainActivity extends AppCompatActivity {
             Update Input permission display.
          */
         TextView inputStatus = findViewById(R.id.permission_status_input);
-        if(InputService.isEnabled()) {
+        if(InputService.isConnected()) {
             inputStatus.setText(R.string.main_activity_granted);
             inputStatus.setTextColor(getColor(android.R.color.holo_green_dark));
         } else {

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -242,7 +242,11 @@ public class MainActivity extends AppCompatActivity {
 
 
         final EditText port = findViewById(R.id.settings_port);
-        port.setText(String.valueOf(prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, mDefaults.getPort())));
+        if(prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, mDefaults.getPort()) < 0) {
+            port.setHint(R.string.main_activity_settings_port_not_listening);
+        } else {
+            port.setText(String.valueOf(prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, mDefaults.getPort())));
+        }
         port.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -71,6 +71,11 @@ public class MainActivity extends AppCompatActivity {
     private Disposable mMainServiceStatusEventStreamConnection;
     private BroadcastReceiver mMainServiceBroadcastReceiver;
     private String mLastMainServiceRequestId;
+    private String mLastReverseHost;
+    private int mLastReversePort;
+    private String mLastRepeaterHost;
+    private int mLastRepeaterPort;
+    private String mLastRepeaterId;
     private Defaults mDefaults;
 
 
@@ -150,6 +155,8 @@ public class MainActivity extends AppCompatActivity {
                         }
                         Log.d(TAG, "reverse vnc " + host + ":" + port);
                         mLastMainServiceRequestId = UUID.randomUUID().toString();
+                        mLastReverseHost = host;
+                        mLastReversePort = port;
                         Intent request = new Intent(MainActivity.this, MainService.class);
                         request.putExtra(MainService.EXTRA_ACCESS_KEY, prefs.getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, mDefaults.getAccessKey()));
                         request.setAction(MainService.ACTION_CONNECT_REVERSE);
@@ -221,6 +228,9 @@ public class MainActivity extends AppCompatActivity {
                         // done
                         Log.d(TAG, "repeater vnc " + host + ":" + port + ":" + repeaterId);
                         mLastMainServiceRequestId = UUID.randomUUID().toString();
+                        mLastRepeaterHost = host;
+                        mLastRepeaterPort = port;
+                        mLastRepeaterId = repeaterId;
                         Intent request = new Intent(MainActivity.this, MainService.class);
                         request.putExtra(MainService.EXTRA_ACCESS_KEY, prefs.getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, mDefaults.getAccessKey()));
                         request.setAction(MainService.ACTION_CONNECT_REPEATER);
@@ -454,19 +464,19 @@ public class MainActivity extends AppCompatActivity {
                     if (intent.getBooleanExtra(MainService.EXTRA_REQUEST_SUCCESS, false)) {
                         Toast.makeText(MainActivity.this,
                                         getString(R.string.main_activity_reverse_vnc_success,
-                                                intent.getStringExtra(MainService.EXTRA_HOST),
-                                                intent.getIntExtra(MainService.EXTRA_PORT, mDefaults.getPortReverse())),
+                                                mLastReverseHost,
+                                                mLastReversePort),
                                         Toast.LENGTH_LONG)
                                 .show();
                         SharedPreferences.Editor ed = prefs.edit();
                         ed.putString(Constants.PREFS_KEY_REVERSE_VNC_LAST_HOST,
-                                intent.getStringExtra(MainService.EXTRA_HOST) + ":" + intent.getIntExtra(MainService.EXTRA_PORT, mDefaults.getPortReverse()));
+                                mLastReverseHost + ":" + mLastReversePort);
                         ed.apply();
                     } else
                         Toast.makeText(MainActivity.this,
                                         getString(R.string.main_activity_reverse_vnc_fail,
-                                                intent.getStringExtra(MainService.EXTRA_HOST),
-                                                intent.getIntExtra(MainService.EXTRA_PORT, mDefaults.getPortReverse())),
+                                                mLastReverseHost,
+                                                mLastReversePort),
                                         Toast.LENGTH_LONG)
                                 .show();
 
@@ -481,24 +491,24 @@ public class MainActivity extends AppCompatActivity {
                     if (intent.getBooleanExtra(MainService.EXTRA_REQUEST_SUCCESS, false)) {
                         Toast.makeText(MainActivity.this,
                                         getString(R.string.main_activity_repeater_vnc_success,
-                                                intent.getStringExtra(MainService.EXTRA_HOST),
-                                                intent.getIntExtra(MainService.EXTRA_PORT, mDefaults.getPortRepeater()),
-                                                intent.getStringExtra(MainService.EXTRA_REPEATER_ID)),
+                                                mLastRepeaterHost,
+                                                mLastRepeaterPort,
+                                                mLastRepeaterId),
                                         Toast.LENGTH_LONG)
                                 .show();
                         SharedPreferences.Editor ed = prefs.edit();
                         ed.putString(Constants.PREFS_KEY_REPEATER_VNC_LAST_HOST,
-                                intent.getStringExtra(MainService.EXTRA_HOST) + ":" + intent.getIntExtra(MainService.EXTRA_PORT, mDefaults.getPortRepeater()));
+                                mLastRepeaterHost + ":" + mLastRepeaterPort);
                         ed.putString(Constants.PREFS_KEY_REPEATER_VNC_LAST_ID,
-                                intent.getStringExtra(MainService.EXTRA_REPEATER_ID));
+                                mLastRepeaterId);
                         ed.apply();
                     }
                     else
                         Toast.makeText(MainActivity.this,
                                         getString(R.string.main_activity_repeater_vnc_fail,
-                                                intent.getStringExtra(MainService.EXTRA_HOST),
-                                                intent.getIntExtra(MainService.EXTRA_PORT, mDefaults.getPortRepeater()),
-                                                intent.getStringExtra(MainService.EXTRA_REPEATER_ID)),
+                                                mLastRepeaterHost,
+                                                mLastRepeaterPort,
+                                                mLastRepeaterId),
                                         Toast.LENGTH_LONG)
                                 .show();
 

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -86,6 +86,8 @@ public class MainActivity extends AppCompatActivity {
         mButtonToggle.setOnClickListener(view -> {
 
             Intent intent = new Intent(MainActivity.this, MainService.class);
+            intent.putExtra(MainService.EXTRA_PORT, prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, mDefaults.getPort()));
+            intent.putExtra(MainService.EXTRA_PASSWORD, prefs.getString(Constants.PREFS_KEY_SETTINGS_PASSWORD, mDefaults.getPassword()));
             intent.putExtra(MainService.EXTRA_ACCESS_KEY, prefs.getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, mDefaults.getAccessKey()));
             if(mIsMainServiceRunning) {
                 intent.setAction(MainService.ACTION_STOP);

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -80,6 +80,7 @@ public class MainActivity extends AppCompatActivity {
         mButtonToggle.setOnClickListener(view -> {
 
             Intent intent = new Intent(MainActivity.this, MainService.class);
+            intent.putExtra(MainService.EXTRA_ACCESS_KEY, prefs.getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, mDefaults.getAccessKey()));
             if(mIsMainServiceRunning) {
                 intent.setAction(MainService.ACTION_STOP);
             }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -89,6 +89,7 @@ public class MainActivity extends AppCompatActivity {
             intent.putExtra(MainService.EXTRA_PORT, prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, mDefaults.getPort()));
             intent.putExtra(MainService.EXTRA_PASSWORD, prefs.getString(Constants.PREFS_KEY_SETTINGS_PASSWORD, mDefaults.getPassword()));
             intent.putExtra(MainService.EXTRA_VIEW_ONLY, prefs.getBoolean(Constants.PREFS_KEY_SETTINGS_VIEW_ONLY, mDefaults.getViewOnly()));
+            intent.putExtra(MainService.EXTRA_SCALING, prefs.getFloat(Constants.PREFS_KEY_SETTINGS_SCALING, mDefaults.getScaling()));
             intent.putExtra(MainService.EXTRA_ACCESS_KEY, prefs.getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, mDefaults.getAccessKey()));
             if(mIsMainServiceRunning) {
                 intent.setAction(MainService.ACTION_STOP);

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -286,6 +286,39 @@ public class MainActivity extends AppCompatActivity {
             password.setSelection(password.getText().length());
         });
 
+        final EditText accessKey = findViewById(R.id.settings_access_key);
+        accessKey.setText(prefs.getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, mDefaults.getAccessKey()));
+        accessKey.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+                // only save new value if it differs from the default
+                if(!charSequence.toString().equals(mDefaults.getAccessKey())) {
+                    SharedPreferences.Editor ed = prefs.edit();
+                    ed.putString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, charSequence.toString());
+                    ed.apply();
+                }
+            }
+
+            @Override
+            public void afterTextChanged(Editable editable) {
+            }
+        });
+        // show/hide access key on focus change. NB that this triggers onTextChanged above, so we have
+        // to take special precautions there.
+        accessKey.setOnFocusChangeListener((v, hasFocus) -> {
+            if (hasFocus) {
+                accessKey.setTransformationMethod(new SingleLineTransformationMethod());
+            } else {
+                accessKey.setTransformationMethod(new PasswordTransformationMethod());
+            }
+            // move cursor to end of text
+            accessKey.setSelection(accessKey.getText().length());
+        });
+
         final SwitchMaterial startOnBoot = findViewById(R.id.settings_start_on_boot);
         startOnBoot.setChecked(prefs.getBoolean(Constants.PREFS_KEY_SETTINGS_START_ON_BOOT, true));
         startOnBoot.setOnCheckedChangeListener((compoundButton, b) -> {
@@ -334,6 +367,7 @@ public class MainActivity extends AppCompatActivity {
                 // indicate that changing these settings does not have an effect when the server is running
                 findViewById(R.id.settings_port).setEnabled(false);
                 findViewById(R.id.settings_password).setEnabled(false);
+                findViewById(R.id.settings_access_key).setEnabled(false);
                 findViewById(R.id.settings_scaling).setEnabled(false);
 
                 mIsMainServiceRunning = true;
@@ -356,6 +390,7 @@ public class MainActivity extends AppCompatActivity {
                 // indicate that changing these settings does have an effect when the server is stopped
                 findViewById(R.id.settings_port).setEnabled(true);
                 findViewById(R.id.settings_password).setEnabled(true);
+                findViewById(R.id.settings_access_key).setEnabled(true);
                 findViewById(R.id.settings_scaling).setEnabled(true);
 
                 mIsMainServiceRunning = false;

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -275,8 +275,8 @@ public class MainActivity extends AppCompatActivity {
 
             @Override
             public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-                // only save new value if it differs from the default
-                if(!charSequence.toString().equals(mDefaults.getPassword())) {
+                // only save new value if it differs from the default and was not saved before
+                if(!(prefs.getString(Constants.PREFS_KEY_SETTINGS_PASSWORD, null) == null && charSequence.toString().equals(mDefaults.getPassword()))) {
                     SharedPreferences.Editor ed = prefs.edit();
                     ed.putString(Constants.PREFS_KEY_SETTINGS_PASSWORD, charSequence.toString());
                     ed.apply();
@@ -309,8 +309,8 @@ public class MainActivity extends AppCompatActivity {
 
             @Override
             public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-                // only save new value if it differs from the default
-                if(!charSequence.toString().equals(mDefaults.getAccessKey())) {
+                // only save new value if it differs from the default and was not saved before
+                if(!(prefs.getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, null) == null && charSequence.toString().equals(mDefaults.getAccessKey()))) {
                     SharedPreferences.Editor ed = prefs.edit();
                     ed.putString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, charSequence.toString());
                     ed.apply();

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -75,6 +75,7 @@ public class MainService extends Service {
     public static final String EXTRA_PORT = "net.christianbeier.droidvnc_ng.EXTRA_PORT";
     public static final String EXTRA_ACCESS_KEY = "net.christianbeier.droidvnc_ng.EXTRA_ACCESS_KEY";
     public static final String EXTRA_PASSWORD = "net.christianbeier.droidvnc_ng.EXTRA_PASSWORD";
+    public static final String EXTRA_VIEW_ONLY = "net.christianbeier.droidvnc_ng.EXTRA_VIEW_ONLY";
 
     final static String ACTION_HANDLE_MEDIA_PROJECTION_RESULT = "action_handle_media_projection_result";
     final static String EXTRA_MEDIA_PROJECTION_RESULT_DATA = "result_data_media_projection";
@@ -261,7 +262,12 @@ public class MainService extends Service {
         if(ACTION_HANDLE_INPUT_RESULT.equals(intent.getAction())) {
             Log.d(TAG, "onStartCommand: handle input result");
             // Step 2: coming back from input permission check, now setup InputService and ask for write storage permission
-            InputService.setScaling(PreferenceManager.getDefaultSharedPreferences(this).getFloat(Constants.PREFS_KEY_SETTINGS_SCALING, mDefaults.getScaling()));
+            if(intent.getBooleanExtra(EXTRA_INPUT_RESULT, false)) {
+                InputService.isEnabled = true;
+                InputService.setScaling(PreferenceManager.getDefaultSharedPreferences(this).getFloat(Constants.PREFS_KEY_SETTINGS_SCALING, mDefaults.getScaling()));
+            } else {
+                InputService.isEnabled = false;
+            }
             Intent writeStorageRequestIntent = new Intent(this, WriteStorageRequestActivity.class);
             writeStorageRequestIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             startActivity(writeStorageRequestIntent);
@@ -283,6 +289,7 @@ public class MainService extends Service {
 
             // Step 1: check input permission
             Intent inputRequestIntent = new Intent(this, InputRequestActivity.class);
+            inputRequestIntent.putExtra(EXTRA_VIEW_ONLY, intent.getBooleanExtra(EXTRA_VIEW_ONLY, mDefaults.getViewOnly()));
             inputRequestIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             startActivity(inputRequestIntent);
             // if screen capturing was not started, we don't want a restart if we were killed

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -320,10 +320,7 @@ public class MainService extends Service {
             Log.d(TAG, "onStartCommand: stop");
             stopSelf();
             Intent answer = new Intent(ACTION_STOP);
-            // use request's extras
-            answer.putExtras(intent);
-            // but don't leak the access key!
-            answer.removeExtra(EXTRA_ACCESS_KEY);
+            answer.putExtra(EXTRA_REQUEST_ID, intent.getStringExtra(EXTRA_REQUEST_ID));
             answer.putExtra(EXTRA_REQUEST_SUCCESS, true);
             sendBroadcast(answer);
             return START_NOT_STICKY;
@@ -343,10 +340,7 @@ public class MainService extends Service {
             }
 
             Intent answer = new Intent(ACTION_CONNECT_REVERSE);
-            // use request's extras
-            answer.putExtras(intent);
-            // but don't leak the access key!
-            answer.removeExtra(EXTRA_ACCESS_KEY);
+            answer.putExtra(EXTRA_REQUEST_ID, intent.getStringExtra(EXTRA_REQUEST_ID));
             answer.putExtra(EXTRA_REQUEST_SUCCESS, status);
             sendBroadcast(answer);
             return START_NOT_STICKY;
@@ -369,10 +363,7 @@ public class MainService extends Service {
             }
 
             Intent answer = new Intent(ACTION_CONNECT_REPEATER);
-            // use request's extras
-            answer.putExtras(intent);
-            // but don't leak the access key!
-            answer.removeExtra(EXTRA_ACCESS_KEY);
+            answer.putExtra(EXTRA_REQUEST_ID, intent.getStringExtra(EXTRA_REQUEST_ID));
             answer.putExtra(EXTRA_REQUEST_SUCCESS, status);
             sendBroadcast(answer);
             return START_NOT_STICKY;

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -465,7 +465,7 @@ public class MainService extends Service {
      * Get whether Media Projection was granted by the user.
      * @return -1 if unknown, 0 if denied, 1 if granted
      */
-    public static int isMediaProjectionEnabled() {
+    static int isMediaProjectionEnabled() {
         if(instance == null)
             return -1;
         if(instance.mResultCode == 0 || instance.mResultData == null)
@@ -474,7 +474,7 @@ public class MainService extends Service {
         return 1;
     }
 
-    public static void togglePortraitInLandscapeWorkaround() {
+    static void togglePortraitInLandscapeWorkaround() {
         try {
             // set
             instance.mHasPortraitInLandscapeWorkaroundSet = true;
@@ -492,7 +492,7 @@ public class MainService extends Service {
      * Get non-loopback IPv4 addresses together with the port the user specified.
      * @return A list of strings in the form IP:port.
      */
-    public static ArrayList<String> getIPv4sAndPorts() {
+    static ArrayList<String> getIPv4sAndPorts() {
 
         int port = 5900;
 

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -77,6 +77,7 @@ public class MainService extends Service {
     public static final String EXTRA_PASSWORD = "net.christianbeier.droidvnc_ng.EXTRA_PASSWORD";
     public static final String EXTRA_VIEW_ONLY = "net.christianbeier.droidvnc_ng.EXTRA_VIEW_ONLY";
     public static final String EXTRA_SCALING = "net.christianbeier.droidvnc_ng.EXTRA_SCALING";
+    public static final String EXTRA_FILE_TRANSFER = "net.christianbeier.droidvnc_ng.EXTRA_FILE_TRANSFER";
 
     final static String ACTION_HANDLE_MEDIA_PROJECTION_RESULT = "action_handle_media_projection_result";
     final static String EXTRA_MEDIA_PROJECTION_RESULT_DATA = "result_data_media_projection";
@@ -279,6 +280,9 @@ public class MainService extends Service {
             // Step 2: coming back from input permission check, now setup InputService and ask for write storage permission
             InputService.isEnabled = intent.getBooleanExtra(EXTRA_INPUT_RESULT, false);
             Intent writeStorageRequestIntent = new Intent(this, WriteStorageRequestActivity.class);
+            writeStorageRequestIntent.putExtra(
+                    EXTRA_FILE_TRANSFER,
+                    PreferenceManager.getDefaultSharedPreferences(this).getBoolean(Constants.PREFS_KEY_SERVER_LAST_FILE_TRANSFER, mDefaults.getFileTranfer()));
             writeStorageRequestIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             startActivity(writeStorageRequestIntent);
             // if screen capturing was not started, we don't want a restart if we were killed
@@ -292,6 +296,7 @@ public class MainService extends Service {
             SharedPreferences.Editor ed = PreferenceManager.getDefaultSharedPreferences(this).edit();
             ed.putInt(Constants.PREFS_KEY_SERVER_LAST_PORT, intent.getIntExtra(EXTRA_PORT, mDefaults.getPort()));
             ed.putString(Constants.PREFS_KEY_SERVER_LAST_PASSWORD, intent.getStringExtra(EXTRA_PASSWORD) != null ? intent.getStringExtra(EXTRA_PASSWORD) : mDefaults.getPassword());
+            ed.putBoolean(Constants.PREFS_KEY_SERVER_LAST_FILE_TRANSFER, intent.getBooleanExtra(EXTRA_FILE_TRANSFER, mDefaults.getFileTranfer()));
             ed.putBoolean(Constants.PREFS_KEY_INPUT_LAST_ENABLED, !intent.getBooleanExtra(EXTRA_VIEW_ONLY, mDefaults.getViewOnly()));
             ed.putFloat(Constants.PREFS_KEY_SERVER_LAST_SCALING, intent.getFloatExtra(EXTRA_SCALING, mDefaults.getScaling()));
             ed.apply();

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -109,6 +109,7 @@ public class MainService extends Service {
 
     private native boolean vncStartServer(int width, int height, int port, String desktopname, String password);
     private native boolean vncStopServer();
+    private native boolean vncIsActive();
     private native boolean vncConnectReverse(String host, int port);
     private native boolean vncConnectRepeater(String host, int port, String repeaterIdentifier);
     private native boolean vncNewFramebuffer(int width, int height);

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -319,6 +319,13 @@ public class MainService extends Service {
         if(ACTION_STOP.equals(intent.getAction())) {
             Log.d(TAG, "onStartCommand: stop");
             stopSelf();
+            Intent answer = new Intent(ACTION_STOP);
+            // use request's extras
+            answer.putExtras(intent);
+            // but don't leak the access key!
+            answer.removeExtra(EXTRA_ACCESS_KEY);
+            answer.putExtra(EXTRA_REQUEST_SUCCESS, true);
+            sendBroadcast(answer);
             return START_NOT_STICKY;
         }
 

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -315,6 +315,15 @@ public class MainService extends Service {
 
         if(ACTION_START.equals(intent.getAction())) {
             Log.d(TAG, "onStartCommand: start");
+
+            if(vncIsActive()) {
+                Intent answer = new Intent(ACTION_START);
+                answer.putExtra(EXTRA_REQUEST_ID, intent.getStringExtra(EXTRA_REQUEST_ID));
+                answer.putExtra(EXTRA_REQUEST_SUCCESS, false);
+                sendBroadcast(answer);
+                return START_NOT_STICKY;
+            }
+
             // Step 0: persist given arguments to be able to recover from possible crash later
             SharedPreferences.Editor ed = PreferenceManager.getDefaultSharedPreferences(this).edit();
             ed.putInt(Constants.PREFS_KEY_SERVER_LAST_PORT, intent.getIntExtra(EXTRA_PORT, mDefaults.getPort()));
@@ -342,7 +351,7 @@ public class MainService extends Service {
             stopSelf();
             Intent answer = new Intent(ACTION_STOP);
             answer.putExtra(EXTRA_REQUEST_ID, intent.getStringExtra(EXTRA_REQUEST_ID));
-            answer.putExtra(EXTRA_REQUEST_SUCCESS, true);
+            answer.putExtra(EXTRA_REQUEST_SUCCESS, vncIsActive());
             sendBroadcast(answer);
             return START_NOT_STICKY;
         }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -330,12 +330,13 @@ public class MainService extends Service {
             }
 
             // Step 0: persist given arguments to be able to recover from possible crash later
-            SharedPreferences.Editor ed = PreferenceManager.getDefaultSharedPreferences(this).edit();
-            ed.putInt(PREFS_KEY_SERVER_LAST_PORT, intent.getIntExtra(EXTRA_PORT, mDefaults.getPort()));
-            ed.putString(PREFS_KEY_SERVER_LAST_PASSWORD, intent.getStringExtra(EXTRA_PASSWORD) != null ? intent.getStringExtra(EXTRA_PASSWORD) : mDefaults.getPassword());
-            ed.putBoolean(PREFS_KEY_SERVER_LAST_FILE_TRANSFER, intent.getBooleanExtra(EXTRA_FILE_TRANSFER, mDefaults.getFileTranfer()));
-            ed.putBoolean(Constants.PREFS_KEY_INPUT_LAST_ENABLED, !intent.getBooleanExtra(EXTRA_VIEW_ONLY, mDefaults.getViewOnly()));
-            ed.putFloat(Constants.PREFS_KEY_SERVER_LAST_SCALING, intent.getFloatExtra(EXTRA_SCALING, mDefaults.getScaling()));
+            final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+            SharedPreferences.Editor ed = prefs.edit();
+            ed.putInt(PREFS_KEY_SERVER_LAST_PORT, intent.getIntExtra(EXTRA_PORT, prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, mDefaults.getPort())));
+            ed.putString(PREFS_KEY_SERVER_LAST_PASSWORD, intent.getStringExtra(EXTRA_PASSWORD) != null ? intent.getStringExtra(EXTRA_PASSWORD) : prefs.getString(Constants.PREFS_KEY_SETTINGS_PASSWORD, mDefaults.getPassword()));
+            ed.putBoolean(PREFS_KEY_SERVER_LAST_FILE_TRANSFER, intent.getBooleanExtra(EXTRA_FILE_TRANSFER, prefs.getBoolean(Constants.PREFS_KEY_SETTINGS_FILE_TRANSFER, mDefaults.getFileTranfer())));
+            ed.putBoolean(Constants.PREFS_KEY_INPUT_LAST_ENABLED, !intent.getBooleanExtra(EXTRA_VIEW_ONLY, prefs.getBoolean(Constants.PREFS_KEY_SETTINGS_VIEW_ONLY, mDefaults.getViewOnly())));
+            ed.putFloat(Constants.PREFS_KEY_SERVER_LAST_SCALING, intent.getFloatExtra(EXTRA_SCALING, prefs.getFloat(Constants.PREFS_KEY_SETTINGS_SCALING, mDefaults.getScaling())));
             ed.putString(PREFS_KEY_SERVER_LAST_START_REQUEST_ID, intent.getStringExtra(EXTRA_REQUEST_ID));
             ed.apply();
             // also set new value for InputService

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -66,7 +66,7 @@ public class MainService extends Service {
 
     private static final String TAG = "MainService";
     private static final int NOTIFICATION_ID = 11;
-    final static String ACTION_START = "start";
+    public final static String ACTION_START = "net.christianbeier.droidvnc_ng.ACTION_START";
     final static String ACTION_STOP = "stop";
     public static final String ACTION_CONNECT_REVERSE = "net.christianbeier.droidvnc_ng.ACTION_CONNECT_REVERSE";
     public static final String EXTRA_REQUEST_ID = "net.christianbeier.droidvnc_ng.EXTRA_REQUEST_ID";
@@ -74,6 +74,7 @@ public class MainService extends Service {
     public static final String EXTRA_HOST = "net.christianbeier.droidvnc_ng.EXTRA_HOST";
     public static final String EXTRA_PORT = "net.christianbeier.droidvnc_ng.EXTRA_PORT";
     public static final String EXTRA_ACCESS_KEY = "net.christianbeier.droidvnc_ng.EXTRA_ACCESS_KEY";
+    public static final String EXTRA_PASSWORD = "net.christianbeier.droidvnc_ng.EXTRA_PASSWORD";
 
     final static String ACTION_HANDLE_MEDIA_PROJECTION_RESULT = "action_handle_media_projection_result";
     final static String EXTRA_MEDIA_PROJECTION_RESULT_DATA = "result_data_media_projection";
@@ -232,15 +233,6 @@ public class MainService extends Service {
             // Step 4 (optional): coming back from capturing permission check, now starting capturing machinery
             mResultCode = intent.getIntExtra(EXTRA_MEDIA_PROJECTION_RESULT_CODE, 0);
             mResultData = intent.getParcelableExtra(EXTRA_MEDIA_PROJECTION_RESULT_DATA);
-
-            DisplayMetrics displayMetrics = getDisplayMetrics();
-            if (!vncStartServer(displayMetrics.widthPixels,
-                    displayMetrics.heightPixels,
-                    PreferenceManager.getDefaultSharedPreferences(this).getInt(Constants.PREFS_KEY_SETTINGS_PORT, mDefaults.getPort()),
-                    Settings.Secure.getString(getContentResolver(), "bluetooth_name"),
-                    PreferenceManager.getDefaultSharedPreferences(this).getString(Constants.PREFS_KEY_SETTINGS_PASSWORD, mDefaults.getPassword())))
-                stopSelf();
-
             startScreenCapture();
             // if we got here, we want to restart if we were killed
             return START_REDELIVER_INTENT;
@@ -251,14 +243,6 @@ public class MainService extends Service {
             // Step 3: coming back from write storage permission check, start capturing
             // or ask for ask for capturing permission first (then going in step 4)
             if (mResultCode != 0 && mResultData != null) {
-                DisplayMetrics displayMetrics = getDisplayMetrics();
-                if (!vncStartServer(displayMetrics.widthPixels,
-                        displayMetrics.heightPixels,
-                        PreferenceManager.getDefaultSharedPreferences(this).getInt(Constants.PREFS_KEY_SETTINGS_PORT, mDefaults.getPort()),
-                        Settings.Secure.getString(getContentResolver(), "bluetooth_name"),
-                        PreferenceManager.getDefaultSharedPreferences(this).getString(Constants.PREFS_KEY_SETTINGS_PASSWORD, mDefaults.getPassword())))
-                    stopSelf();
-
                 startScreenCapture();
                 // if we got here, we want to restart if we were killed
                 return START_REDELIVER_INTENT;
@@ -288,6 +272,15 @@ public class MainService extends Service {
 
         if(ACTION_START.equals(intent.getAction())) {
             Log.d(TAG, "onStartCommand: start");
+            // Step 0: start server w/ provided arguments
+            DisplayMetrics displayMetrics = getDisplayMetrics();
+            if (!vncStartServer(displayMetrics.widthPixels,
+                    displayMetrics.heightPixels,
+                    intent.getIntExtra(EXTRA_PORT, mDefaults.getPort()),
+                    Settings.Secure.getString(getContentResolver(), "bluetooth_name"),
+                    intent.getStringExtra(EXTRA_PASSWORD) != null ? intent.getStringExtra(EXTRA_PASSWORD) : mDefaults.getPassword()))
+                stopSelf();
+
             // Step 1: check input permission
             Intent inputRequestIntent = new Intent(this, InputRequestActivity.class);
             inputRequestIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -632,7 +632,7 @@ public class MainService extends Service {
 
         try {
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(instance);
-            port = prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, 5900);
+            port = prefs.getInt(PREFS_KEY_SERVER_LAST_PORT, new Defaults(instance).getPort());
         } catch (NullPointerException e) {
             //unused
         }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -251,6 +251,9 @@ public class MainService extends Service {
                 Intent mediaProjectionRequestIntent = new Intent(this, MediaProjectionRequestActivity.class);
                 mediaProjectionRequestIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 startActivity(mediaProjectionRequestIntent);
+                // if screen capturing was not started, we don't want a restart if we were killed
+                // especially, we don't want the permission asking to replay.
+                return START_NOT_STICKY;
             }
         }
 
@@ -261,6 +264,9 @@ public class MainService extends Service {
             Intent writeStorageRequestIntent = new Intent(this, WriteStorageRequestActivity.class);
             writeStorageRequestIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             startActivity(writeStorageRequestIntent);
+            // if screen capturing was not started, we don't want a restart if we were killed
+            // especially, we don't want the permission asking to replay.
+            return START_NOT_STICKY;
         }
 
         if(ACTION_START.equals(intent.getAction())) {
@@ -269,15 +275,22 @@ public class MainService extends Service {
             Intent inputRequestIntent = new Intent(this, InputRequestActivity.class);
             inputRequestIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             startActivity(inputRequestIntent);
+            // if screen capturing was not started, we don't want a restart if we were killed
+            // especially, we don't want the permission asking to replay.
+            return START_NOT_STICKY;
         }
 
         if(ACTION_STOP.equals(intent.getAction())) {
             Log.d(TAG, "onStartCommand: stop");
             stopSelf();
+            return START_NOT_STICKY;
         }
 
-        // if screen capturing was not started, we don't want a restart if we were killed
-        // especially, we don't want the permission asking to replay.
+        // no known action was given, stop the _service_ again if the _server_ is not active
+        if(!vncIsActive()) {
+            stopSelf();
+        }
+
         return START_NOT_STICKY;
     }
 

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -279,7 +279,7 @@ public class MainService extends Service {
     }
 
     @SuppressLint("WakelockTimeout")
-    public static void onClientConnected(long client) {
+    static void onClientConnected(long client) {
         Log.d(TAG, "onClientConnected: client " + client);
 
         try {
@@ -290,7 +290,7 @@ public class MainService extends Service {
         }
     }
 
-    public static void onClientDisconnected(long client) {
+    static void onClientDisconnected(long client) {
         Log.d(TAG, "onClientDisconnected: client " + client);
 
         try {

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -67,7 +67,7 @@ public class MainService extends Service {
     private static final String TAG = "MainService";
     private static final int NOTIFICATION_ID = 11;
     public final static String ACTION_START = "net.christianbeier.droidvnc_ng.ACTION_START";
-    final static String ACTION_STOP = "stop";
+    public final static String ACTION_STOP = "net.christianbeier.droidvnc_ng.ACTION_STOP";
     public static final String ACTION_CONNECT_REVERSE = "net.christianbeier.droidvnc_ng.ACTION_CONNECT_REVERSE";
     public static final String EXTRA_REQUEST_ID = "net.christianbeier.droidvnc_ng.EXTRA_REQUEST_ID";
     public static final String EXTRA_REQUEST_SUCCESS = "net.christianbeier.droidvnc_ng.EXTRA_REQUEST_SUCCESS";

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -91,6 +91,11 @@ public class MainService extends Service {
     final static String ACTION_HANDLE_WRITE_STORAGE_RESULT = "action_handle_write_storage_result";
     final static String EXTRA_WRITE_STORAGE_RESULT = "result_write_storage";
 
+    private static final String PREFS_KEY_SERVER_LAST_PORT = "server_last_port" ;
+    private static final String PREFS_KEY_SERVER_LAST_PASSWORD = "server_last_password" ;
+    private static final String PREFS_KEY_SERVER_LAST_FILE_TRANSFER = "server_last_file_transfer" ;
+    private static final String PREFS_KEY_SERVER_LAST_START_REQUEST_ID = "server_last_start_request_id" ;
+
     private int mResultCode;
     private Intent mResultData;
     private ImageReader mImageReader;
@@ -242,12 +247,12 @@ public class MainService extends Service {
             DisplayMetrics displayMetrics = getDisplayMetrics();
             boolean status = vncStartServer(displayMetrics.widthPixels,
                     displayMetrics.heightPixels,
-                    PreferenceManager.getDefaultSharedPreferences(this).getInt(Constants.PREFS_KEY_SERVER_LAST_PORT, mDefaults.getPort()),
+                    PreferenceManager.getDefaultSharedPreferences(this).getInt(PREFS_KEY_SERVER_LAST_PORT, mDefaults.getPort()),
                     Settings.Secure.getString(getContentResolver(), "bluetooth_name"),
-                    PreferenceManager.getDefaultSharedPreferences(this).getString(Constants.PREFS_KEY_SERVER_LAST_PASSWORD, mDefaults.getPassword()));
+                    PreferenceManager.getDefaultSharedPreferences(this).getString(PREFS_KEY_SERVER_LAST_PASSWORD, mDefaults.getPassword()));
 
             Intent answer = new Intent(ACTION_START);
-            answer.putExtra(EXTRA_REQUEST_ID, PreferenceManager.getDefaultSharedPreferences(this).getString(Constants.PREFS_KEY_SERVER_LAST_START_REQUEST_ID, null));
+            answer.putExtra(EXTRA_REQUEST_ID, PreferenceManager.getDefaultSharedPreferences(this).getString(PREFS_KEY_SERVER_LAST_START_REQUEST_ID, null));
             answer.putExtra(EXTRA_REQUEST_SUCCESS, status);
             sendBroadcast(answer);
 
@@ -269,12 +274,12 @@ public class MainService extends Service {
                 DisplayMetrics displayMetrics = getDisplayMetrics();
                 boolean status = vncStartServer(displayMetrics.widthPixels,
                         displayMetrics.heightPixels,
-                        PreferenceManager.getDefaultSharedPreferences(this).getInt(Constants.PREFS_KEY_SERVER_LAST_PORT, mDefaults.getPort()),
+                        PreferenceManager.getDefaultSharedPreferences(this).getInt(PREFS_KEY_SERVER_LAST_PORT, mDefaults.getPort()),
                         Settings.Secure.getString(getContentResolver(), "bluetooth_name"),
-                        PreferenceManager.getDefaultSharedPreferences(this).getString(Constants.PREFS_KEY_SERVER_LAST_PASSWORD, mDefaults.getPassword()));
+                        PreferenceManager.getDefaultSharedPreferences(this).getString(PREFS_KEY_SERVER_LAST_PASSWORD, mDefaults.getPassword()));
 
                 Intent answer = new Intent(ACTION_START);
-                answer.putExtra(EXTRA_REQUEST_ID, PreferenceManager.getDefaultSharedPreferences(this).getString(Constants.PREFS_KEY_SERVER_LAST_START_REQUEST_ID, null));
+                answer.putExtra(EXTRA_REQUEST_ID, PreferenceManager.getDefaultSharedPreferences(this).getString(PREFS_KEY_SERVER_LAST_START_REQUEST_ID, null));
                 answer.putExtra(EXTRA_REQUEST_SUCCESS, status);
                 sendBroadcast(answer);
 
@@ -305,7 +310,7 @@ public class MainService extends Service {
             Intent writeStorageRequestIntent = new Intent(this, WriteStorageRequestActivity.class);
             writeStorageRequestIntent.putExtra(
                     EXTRA_FILE_TRANSFER,
-                    PreferenceManager.getDefaultSharedPreferences(this).getBoolean(Constants.PREFS_KEY_SERVER_LAST_FILE_TRANSFER, mDefaults.getFileTranfer()));
+                    PreferenceManager.getDefaultSharedPreferences(this).getBoolean(PREFS_KEY_SERVER_LAST_FILE_TRANSFER, mDefaults.getFileTranfer()));
             writeStorageRequestIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             startActivity(writeStorageRequestIntent);
             // if screen capturing was not started, we don't want a restart if we were killed
@@ -326,12 +331,12 @@ public class MainService extends Service {
 
             // Step 0: persist given arguments to be able to recover from possible crash later
             SharedPreferences.Editor ed = PreferenceManager.getDefaultSharedPreferences(this).edit();
-            ed.putInt(Constants.PREFS_KEY_SERVER_LAST_PORT, intent.getIntExtra(EXTRA_PORT, mDefaults.getPort()));
-            ed.putString(Constants.PREFS_KEY_SERVER_LAST_PASSWORD, intent.getStringExtra(EXTRA_PASSWORD) != null ? intent.getStringExtra(EXTRA_PASSWORD) : mDefaults.getPassword());
-            ed.putBoolean(Constants.PREFS_KEY_SERVER_LAST_FILE_TRANSFER, intent.getBooleanExtra(EXTRA_FILE_TRANSFER, mDefaults.getFileTranfer()));
+            ed.putInt(PREFS_KEY_SERVER_LAST_PORT, intent.getIntExtra(EXTRA_PORT, mDefaults.getPort()));
+            ed.putString(PREFS_KEY_SERVER_LAST_PASSWORD, intent.getStringExtra(EXTRA_PASSWORD) != null ? intent.getStringExtra(EXTRA_PASSWORD) : mDefaults.getPassword());
+            ed.putBoolean(PREFS_KEY_SERVER_LAST_FILE_TRANSFER, intent.getBooleanExtra(EXTRA_FILE_TRANSFER, mDefaults.getFileTranfer()));
             ed.putBoolean(Constants.PREFS_KEY_INPUT_LAST_ENABLED, !intent.getBooleanExtra(EXTRA_VIEW_ONLY, mDefaults.getViewOnly()));
             ed.putFloat(Constants.PREFS_KEY_SERVER_LAST_SCALING, intent.getFloatExtra(EXTRA_SCALING, mDefaults.getScaling()));
-            ed.putString(Constants.PREFS_KEY_SERVER_LAST_START_REQUEST_ID, intent.getStringExtra(EXTRA_REQUEST_ID));
+            ed.putString(PREFS_KEY_SERVER_LAST_START_REQUEST_ID, intent.getStringExtra(EXTRA_REQUEST_ID));
             ed.apply();
             // also set new value for InputService
             InputService.scaling = intent.getFloatExtra(EXTRA_SCALING, mDefaults.getScaling());

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -119,7 +119,8 @@ public class MainService extends Service {
         System.loadLibrary("droidvnc-ng");
     }
 
-    private native boolean vncStartServer(int width, int height, int port, String desktopname, String password);
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    private native boolean vncStartServer(int width, int height, int port, String desktopName, String password);
     private native boolean vncStopServer();
     private native boolean vncIsActive();
     private native boolean vncConnectReverse(String host, int port);
@@ -379,6 +380,7 @@ public class MainService extends Service {
     }
 
     @SuppressLint("WakelockTimeout")
+    @SuppressWarnings("unused")
     static void onClientConnected(long client) {
         Log.d(TAG, "onClientConnected: client " + client);
 
@@ -390,6 +392,7 @@ public class MainService extends Service {
         }
     }
 
+    @SuppressWarnings("unused")
     static void onClientDisconnected(long client) {
         Log.d(TAG, "onClientDisconnected: client " + client);
 

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -120,7 +120,7 @@ public class MainService extends Service {
     public MainService() {
     }
 
-    public static Observable<StatusEvent> getStatusEventStream() {
+    static Observable<StatusEvent> getStatusEventStream() {
         return mStatusEventStream;
     }
 

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -68,6 +68,7 @@ public class MainService extends Service {
     private static final int NOTIFICATION_ID = 11;
     final static String ACTION_START = "start";
     final static String ACTION_STOP = "stop";
+    public static final String EXTRA_ACCESS_KEY = "net.christianbeier.droidvnc_ng.EXTRA_ACCESS_KEY";
 
     final static String ACTION_HANDLE_MEDIA_PROJECTION_RESULT = "action_handle_media_projection_result";
     final static String EXTRA_MEDIA_PROJECTION_RESULT_DATA = "result_data_media_projection";
@@ -210,6 +211,17 @@ public class MainService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId)
     {
+        String accessKey = intent.getStringExtra(EXTRA_ACCESS_KEY);
+        if (accessKey == null
+                || accessKey.isEmpty()
+                || !accessKey.equals(PreferenceManager.getDefaultSharedPreferences(this).getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, mDefaults.getAccessKey()))) {
+            Log.e(TAG, "Access key missing or incorrect");
+            if(!vncIsActive()) {
+                stopSelf();
+            }
+            return START_NOT_STICKY;
+        }
+
         if(ACTION_HANDLE_MEDIA_PROJECTION_RESULT.equals(intent.getAction())) {
             Log.d(TAG, "onStartCommand: handle media projection result");
             // Step 4 (optional): coming back from capturing permission check, now starting capturing machinery

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MediaProjectionRequestActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MediaProjectionRequestActivity.java
@@ -23,6 +23,7 @@
 package net.christianbeier.droidvnc_ng;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.preference.PreferenceManager;
 
 import android.app.Activity;
 import android.content.Context;
@@ -61,6 +62,7 @@ public class MediaProjectionRequestActivity extends AppCompatActivity {
 
             Intent intent = new Intent(this, MainService.class);
             intent.setAction(MainService.ACTION_HANDLE_MEDIA_PROJECTION_RESULT);
+            intent.putExtra(MainService.EXTRA_ACCESS_KEY, PreferenceManager.getDefaultSharedPreferences(this).getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, new Defaults(this).getAccessKey()));
             intent.putExtra(MainService.EXTRA_MEDIA_PROJECTION_RESULT_CODE, resultCode);
             intent.putExtra(MainService.EXTRA_MEDIA_PROJECTION_RESULT_DATA, data);
             startService(intent);

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/OnBootReceiver.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/OnBootReceiver.java
@@ -43,6 +43,7 @@ public class OnBootReceiver extends BroadcastReceiver {
             Log.i(TAG, "onReceive: configured to start");
             Intent intent = new Intent(context, MainService.class);
             intent.setAction(MainService.ACTION_START);
+            intent.putExtra(MainService.EXTRA_ACCESS_KEY, prefs.getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, new Defaults(context).getAccessKey()));
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 context.startForegroundService(intent);
             } else {

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/OnBootReceiver.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/OnBootReceiver.java
@@ -41,9 +41,18 @@ public class OnBootReceiver extends BroadcastReceiver {
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         if(prefs.getBoolean(Constants.PREFS_KEY_SETTINGS_START_ON_BOOT, true)) {
             Log.i(TAG, "onReceive: configured to start");
+
+            Defaults defaults = new Defaults(context);
+
             Intent intent = new Intent(context, MainService.class);
             intent.setAction(MainService.ACTION_START);
-            intent.putExtra(MainService.EXTRA_ACCESS_KEY, prefs.getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, new Defaults(context).getAccessKey()));
+            intent.putExtra(MainService.EXTRA_PORT, prefs.getInt(Constants.PREFS_KEY_SETTINGS_PORT, defaults.getPort()));
+            intent.putExtra(MainService.EXTRA_PASSWORD, prefs.getString(Constants.PREFS_KEY_SETTINGS_PASSWORD, defaults.getPassword()));
+            intent.putExtra(MainService.EXTRA_FILE_TRANSFER, prefs.getBoolean(Constants.PREFS_KEY_SETTINGS_FILE_TRANSFER, defaults.getFileTranfer()));
+            intent.putExtra(MainService.EXTRA_VIEW_ONLY, prefs.getBoolean(Constants.PREFS_KEY_SETTINGS_VIEW_ONLY, defaults.getViewOnly()));
+            intent.putExtra(MainService.EXTRA_SCALING, prefs.getFloat(Constants.PREFS_KEY_SETTINGS_SCALING, defaults.getScaling()));
+            intent.putExtra(MainService.EXTRA_ACCESS_KEY, prefs.getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, defaults.getAccessKey()));
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 context.startForegroundService(intent);
             } else {

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/WriteStorageRequestActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/WriteStorageRequestActivity.java
@@ -92,6 +92,7 @@ public class WriteStorageRequestActivity extends AppCompatActivity {
 
         Intent intent = new Intent(this, MainService.class);
         intent.setAction(MainService.ACTION_HANDLE_WRITE_STORAGE_RESULT);
+        intent.putExtra(MainService.EXTRA_ACCESS_KEY, PreferenceManager.getDefaultSharedPreferences(this).getString(Constants.PREFS_KEY_SETTINGS_ACCESS_KEY, new Defaults(this).getAccessKey()));
         intent.putExtra(MainService.EXTRA_WRITE_STORAGE_RESULT, isPermissionGiven);
         startService(intent);
         finish();

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/WriteStorageRequestActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/WriteStorageRequestActivity.java
@@ -44,6 +44,12 @@ public class WriteStorageRequestActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        // if file transfer not wanted, bail out early without bothering the user
+        if(!getIntent().getBooleanExtra(MainService.EXTRA_FILE_TRANSFER, new Defaults(this).getFileTranfer())) {
+            postResultAndFinish(false);
+            return;
+        }
+
         if (checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
             Log.i(TAG, "Has no permission! Ask!");
             final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -148,6 +148,35 @@
                     android:layout_height="wrap_content"
                     android:layout_column="0"
                     android:padding="10dp"
+                    android:text="@string/main_activity_settings_file_transfer" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_column="1"
+                    android:padding="10dp"
+                    android:text="@string/main_activity_colon" />
+
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/settings_file_transfer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_column="2"
+                    android:layout_weight="1"
+                    android:text="" />
+
+            </TableRow>
+
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_column="0"
+                    android:padding="10dp"
                     android:text="@string/main_activity_settings_scaling" />
 
                 <TextView

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -171,6 +171,35 @@
 
             </TableRow>
 
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_column="0"
+                    android:padding="10dp"
+                    android:text="@string/main_activity_settings_view_only" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_column="1"
+                    android:padding="10dp"
+                    android:text="@string/main_activity_colon" />
+
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/settings_view_only"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_column="2"
+                    android:layout_weight="1"
+                    android:text="" />
+
+            </TableRow>
+
         </TableLayout>
 
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -91,6 +91,35 @@
                     android:layout_height="wrap_content"
                     android:layout_column="0"
                     android:padding="10dp"
+                    android:text="@string/main_activity_settings_access_key" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_column="1"
+                    android:padding="10dp"
+                    android:text="@string/main_activity_colon" />
+
+                <EditText
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_column="2"
+                    android:padding="10dp"
+                    android:layout_weight="1"
+                    android:inputType="textPassword"
+                    android:id="@+id/settings_access_key"/>
+
+            </TableRow>
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_column="0"
+                    android:padding="10dp"
                     android:text="@string/main_activity_settings_start_on_boot" />
 
                 <TextView

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -3,6 +3,7 @@
     <string name="main_activity_title">droidVNC-NG管理面板</string>
     <string name="main_activity_settings">设置</string>
     <string name="main_activity_settings_port">端口</string>
+    <string name="main_activity_settings_port_not_listening">禁用传入连接</string>
     <string name="main_activity_settings_password">密码</string>
     <string name="main_activity_settings_access_key">访问键</string>
     <string name="main_activity_settings_start_on_boot">开机启动</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -7,6 +7,7 @@
     <string name="main_activity_settings_access_key">访问键</string>
     <string name="main_activity_settings_start_on_boot">开机启动</string>
     <string name="main_activity_settings_scaling">缩放</string>
+    <string name="main_activity_settings_view_only">只读</string>
     <string name="main_activity_permissions_dashboard">权限仪表盘</string>
     <string name="main_activity_colon">：</string>
     <string name="main_activity_screen_capturing">截屏</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -6,6 +6,7 @@
     <string name="main_activity_settings_password">密码</string>
     <string name="main_activity_settings_access_key">访问键</string>
     <string name="main_activity_settings_start_on_boot">开机启动</string>
+    <string name="main_activity_settings_file_transfer">文件传输</string>
     <string name="main_activity_settings_scaling">缩放</string>
     <string name="main_activity_settings_view_only">只读</string>
     <string name="main_activity_permissions_dashboard">权限仪表盘</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -4,6 +4,7 @@
     <string name="main_activity_settings">设置</string>
     <string name="main_activity_settings_port">端口</string>
     <string name="main_activity_settings_password">密码</string>
+    <string name="main_activity_settings_access_key">访问键</string>
     <string name="main_activity_settings_start_on_boot">开机启动</string>
     <string name="main_activity_settings_scaling">缩放</string>
     <string name="main_activity_permissions_dashboard">权限仪表盘</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="main_activity_title">droidVNC-NG Admin Panel</string>
     <string name="main_activity_settings">Settings</string>
     <string name="main_activity_settings_port">Port</string>
+    <string name="main_activity_settings_port_not_listening">Incoming connections disabled</string>
     <string name="main_activity_settings_password">Password</string>
     <string name="main_activity_settings_access_key">Access Key</string>
     <string name="main_activity_settings_start_on_boot">Start on Boot</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="main_activity_settings_password">Password</string>
     <string name="main_activity_settings_access_key">Access Key</string>
     <string name="main_activity_settings_start_on_boot">Start on Boot</string>
+    <string name="main_activity_settings_file_transfer">File Transfer</string>
     <string name="main_activity_settings_scaling">Scaling</string>
     <string name="main_activity_settings_view_only">View Only</string>
     <string name="main_activity_permissions_dashboard">Permissions Dashboard</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="main_activity_title">droidVNC-NG Admin Panel</string>
     <string name="main_activity_settings">Settings</string>
     <string name="main_activity_settings_port">Port</string>
-    <string name="main_activity_settings_port_not_listening">Incoming connections disabled</string>
+    <string name="main_activity_settings_port_not_listening">Inbound connections disabled</string>
     <string name="main_activity_settings_password">Password</string>
     <string name="main_activity_settings_access_key">Access Key</string>
     <string name="main_activity_settings_start_on_boot">Start on Boot</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="main_activity_settings">Settings</string>
     <string name="main_activity_settings_port">Port</string>
     <string name="main_activity_settings_password">Password</string>
+    <string name="main_activity_settings_access_key">Access Key</string>
     <string name="main_activity_settings_start_on_boot">Start on Boot</string>
     <string name="main_activity_settings_scaling">Scaling</string>
     <string name="main_activity_permissions_dashboard">Permissions Dashboard</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="main_activity_settings_access_key">Access Key</string>
     <string name="main_activity_settings_start_on_boot">Start on Boot</string>
     <string name="main_activity_settings_scaling">Scaling</string>
+    <string name="main_activity_settings_view_only">View Only</string>
     <string name="main_activity_permissions_dashboard">Permissions Dashboard</string>
     <string name="main_activity_colon">:</string>
     <string name="main_activity_screen_capturing">Screen Capturing</string>


### PR DESCRIPTION
This refactors the code to enable starting the MainService from the outside via an Intent interface.

Closes #83, closes #71, closes #40, closes #50, closes #95, closes #118.

Builds upon and obsoletes #84.

- [x] move eligible static methods to intents
- [x] test service start when stopped -> service can be started from other app if startForegroundService() is used
- [x] test START_REDELIVER_INTENT behaviour -> an intent where onStartCommand returns START_REDELIVER_INTENT gets redeliverd even if there was an onStartCommand that returned START_NOT_STICKY after it which is *good* :bulb: 
- [x] onStartCommand return value
- [x] feedback on calls via broadcast
- [x] remove SharedPrefs from MainService? -> no, it's needed
- [x] make some prefs keys component-private
- [x] add to onbootreceiver
- [x] API docs
- [x] extra settings in UI
- [ ] API examples, especially for #83, #71 and #40.
- [x] permissions like in https://github.com/bk138/droidVNC-NG/pull/84#discussion_r876759227 ? -> won't work this way as most automater apps don't have permission asking *and* `adb pm grant` also does not work because those 3rd party apps have not declared to use our custom permission...
- [x] custom access control
