### PR TITLE
Added support for latin characters (ISO 8859-1)

### DIFF
--- a/app/src/main/cpp/droidvnc-ng.c
+++ b/app/src/main/cpp/droidvnc-ng.c
@@ -103,30 +103,6 @@ static void onKeyEvent(rfbBool down, rfbKeySym key, rfbClientPtr cl)
     (*theVM)->DetachCurrentThread(theVM);
 }
 
-/*
- * Is equivalent to calling Charset.forName("ISO-8859-1").decode(byteBuffer).toString()
- */
-static jstring stringDecode(JNIEnv *env, const char* text)
-{
-    jobject byteBuffer = (*env)->NewDirectByteBuffer(env, (jbyte *)text, strlen(text));
-
-    //Charset charset = Charset.forName("ISO-8859-1")
-    jclass clsCharset =  (*env)->FindClass(env,"java/nio/charset/Charset");
-    jmethodID midCharsetForName = (*env)->GetStaticMethodID(env, clsCharset, "forName", "(Ljava/lang/String;)Ljava/nio/charset/Charset;");
-    jobject charset = (*env)->CallStaticObjectMethod(env, clsCharset, midCharsetForName, (*env)->NewStringUTF(env, "ISO-8859-1"));
-
-    //CharBuffer charBuffer = charset.decode(byteBuffer)
-    jmethodID midCharsetDecode = (*env)->GetMethodID(env, clsCharset, "decode", "(Ljava/nio/ByteBuffer;)Ljava/nio/CharBuffer;");
-    jobject charBuffer = (*env)->CallObjectMethod(env, charset, midCharsetDecode, byteBuffer);
-    (*env)->DeleteLocalRef(env, byteBuffer);
-
-    //String result = charBuffer.toString();
-    jclass clsCharBuffer = (*env)->FindClass(env, "java/nio/CharBuffer");
-    jmethodID midCharBufferToString = (*env)->GetMethodID(env, clsCharBuffer, "toString", "()Ljava/lang/String;");
-    jstring result = (*env)->CallObjectMethod(env, charBuffer, midCharBufferToString);
-    return result;
-}
-
 static void onCutText(char *text, __unused int len, rfbClientPtr cl)
 {
     JNIEnv *env = NULL;
@@ -135,8 +111,24 @@ static void onCutText(char *text, __unused int len, rfbClientPtr cl)
         return;
     }
 
+    //Charset charset = Charset.forName("ISO-8859-1")
+    jclass clsCharset =  (*env)->FindClass(env,"java/nio/charset/Charset");
+    jmethodID midCharsetForName = (*env)->GetStaticMethodID(env, clsCharset, "forName", "(Ljava/lang/String;)Ljava/nio/charset/Charset;");
+    jobject charset = (*env)->CallStaticObjectMethod(env, clsCharset, midCharsetForName, (*env)->NewStringUTF(env, "ISO-8859-1"));
+
+    //CharBuffer charBuffer = charset.decode(byteBuffer)
+    jobject byteBuffer = (*env)->NewDirectByteBuffer(env, (jbyte *)text, strlen(text));
+    jmethodID midCharsetDecode = (*env)->GetMethodID(env, clsCharset, "decode", "(Ljava/nio/ByteBuffer;)Ljava/nio/CharBuffer;");
+    jobject charBuffer = (*env)->CallObjectMethod(env, charset, midCharsetDecode, byteBuffer);
+    (*env)->DeleteLocalRef(env, byteBuffer);
+
+    //String jText = charBuffer.toString();
+    jclass clsCharBuffer = (*env)->FindClass(env, "java/nio/CharBuffer");
+    jmethodID midCharBufferToString = (*env)->GetMethodID(env, clsCharBuffer, "toString", "()Ljava/lang/String;");
+    jstring jText = (*env)->CallObjectMethod(env, charBuffer, midCharBufferToString);
+    (*env)->DeleteLocalRef(env, charBuffer);
+
     jmethodID mid = (*env)->GetStaticMethodID(env, theInputService, "onCutText", "(Ljava/lang/String;J)V");
-    jstring jText = stringDecode(env, text);
     (*env)->CallStaticVoidMethod(env, theInputService, mid, jText, (jlong)cl);
 
     (*env)->DeleteLocalRef(env, jText);


### PR DESCRIPTION
To fix error when copying special characters from the client which caused a crash in the application.

java_vm_ext.cc:578] JNI DETECTED ERROR IN APPLICATION: input is not valid Modified UTF-8: illegal continuation byte 0x6f
 A  java_vm_ext.cc:578]     string: 'Logro?o'
 A  java_vm_ext.cc:578]     input: '0x4c 0x6f 0x67 0x72 0x6f 0xf1 <0x6f>'
 A  java_vm_ext.cc:578]     in call to NewStringUTF
 A  runtime.cc:642] Runtime aborting...
 A  runtime.cc:642] Dumping all threads without mutator lock held
 A  runtime.cc:642] All threads:
 A  runtime.cc:642] DALVIK THREADS (17):
 A  runtime.cc:642] "Thread-35" prio=10 tid=4 Runnable
 A  runtime.cc:642]   | group="" sCount=0 dsCount=0 flags=0 obj=0x13600000 self=0x730fa0e000
 A  runtime.cc:642]   | sysTid=15570 nice=-10 cgrp=default sched=0/0 handle=0x730d818d50
 A  runtime.cc:642]   | state=R schedstat=( 133720741 41621648 584 ) utm=4 stm=8 core=4 HZ=100
 A  runtime.cc:642]   | stack=0x730d722000-0x730d724000 stackSize=991KB
 A  runtime.cc:642]   | held mutexes= "abort lock" "mutator lock"(shared held)