### PR TITLE
InputService: add basic ASCII keyboard handling

### DIFF
--- a/app/src/main/res/xml-v30/input_service_config.xml
+++ b/app/src/main/res/xml-v30/input_service_config.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- On API 30 and later flagRetrieveInteractiveWindows canRetrieveWindowContent
+     are needed for onAccessibilityEvent() to trigger  -->
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
-    android:accessibilityEventTypes="typeWindowsChanged"
-    android:accessibilityFlags="flagDefault"
-    android:notificationTimeout="50"
+	android:accessibilityEventTypes="typeViewFocused|typeViewClicked|typeViewSelected|typeViewTextChanged|typeViewTextSelectionChanged"
+    android:accessibilityFlags="flagDefault|flagRetrieveInteractiveWindows"
+    android:notificationTimeout="30"
 	android:description="@string/input_a11y_service_description"
 	android:canPerformGestures="true"
 	android:canTakeScreenshot="true"
+	android:canRetrieveWindowContent="true"
     />

--- a/app/src/main/res/xml/input_service_config.xml
+++ b/app/src/main/res/xml/input_service_config.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- accessibilityFeedbackType seems needed pre API 30 so onAccessibilityEvent() triggers,
+ 	 but it seems we don't need flagRetrieveInteractiveWindows -->
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
-    android:accessibilityEventTypes="typeWindowsChanged"
-    android:accessibilityFlags="flagDefault"
-    android:notificationTimeout="50"
+    android:accessibilityEventTypes="typeViewFocused|typeViewClicked|typeViewSelected|typeViewTextChanged|typeViewTextSelectionChanged"
+	android:accessibilityFlags="flagDefault"
+    android:notificationTimeout="30"
 	android:description="@string/input_a11y_service_description"
 	android:canPerformGestures="true"
-    />
+	android:canRetrieveWindowContent="true"
+	android:accessibilityFeedbackType="feedbackVisual"
+	/>


### PR DESCRIPTION
This implements additional keyboard input from VNC viewers in the form of:

- ASCII characters, i.e. basic typing
- Left and Right arrow handling to select text cursor position
- Delete and Backspace handling for editing text
- Enter/Return handling on API level >= 30

All display-specific, i.e. provides one keyboard focus per display.

Closes #4, finally.