### PR TITLE
Added possibility to configure interface bindings

### DIFF
--- a/app/src/main/cpp/droidvnc-ng.c
+++ b/app/src/main/cpp/droidvnc-ng.c
@@ -277,7 +277,7 @@ JNIEXPORT jboolean JNICALL Java_net_christianbeier_droidvnc_1ng_MainService_vncS
 }
 
 
-JNIEXPORT jboolean JNICALL Java_net_christianbeier_droidvnc_1ng_MainService_vncStartServer(JNIEnv *env, jobject thiz, jint width, jint height, jint port, jstring desktopname, jstring password, jstring httpRootDir) {
+JNIEXPORT jboolean JNICALL Java_net_christianbeier_droidvnc_1ng_MainService_vncStartServer(JNIEnv *env, jobject thiz, jint width, jint height, jstring listenIf, jint port, jstring desktopname, jstring password, jstring httpRootDir) {
 
     int argc = 0;
 
@@ -305,6 +305,22 @@ JNIEXPORT jboolean JNICALL Java_net_christianbeier_droidvnc_1ng_MainService_vncS
     theScreen->setXCutTextUTF8 = onCutTextUTF8;
     theScreen->newClientHook = onClientConnected;
 
+    in_addr_t address = 0; // Default is 0.0.0.0
+    if (listenIf != NULL) {
+        const char *cListenInterface = (*env)->GetStringUTFChars(env, listenIf, NULL);
+        int addrConvSucceded = rfbStringToAddr((char*)cListenInterface, &address);
+        (*env)->ReleaseStringUTFChars(env, listenIf, cListenInterface);
+
+        if (!addrConvSucceded) {
+            __android_log_print(ANDROID_LOG_ERROR, TAG, "vncStartServer: invalid listen address");
+            Java_net_christianbeier_droidvnc_1ng_MainService_vncStopServer(env, thiz);
+            return JNI_FALSE;
+        }
+    }
+
+
+    // With the listenInterface property one can define where the server will be available
+    theScreen->listenInterface = address;
     theScreen->port = port;
     theScreen->ipv6port = port;
 

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Constants.java
@@ -25,6 +25,7 @@ public class Constants {
     /*
         user settings
      */
+    public static final String PREFS_KEY_SETTINGS_LISTEN_INTERFACE = "settings_listen_interface";
     public static final String PREFS_KEY_SETTINGS_PORT = "settings_port";
     public static final String PREFS_KEY_SETTINGS_PASSWORD = "settings_password" ;
     public static final String PREFS_KEY_SETTINGS_START_ON_BOOT = "settings_start_on_boot" ;

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/Defaults.kt
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/Defaults.kt
@@ -42,6 +42,10 @@ class Defaults {
     }
 
     @EncodeDefault
+    var listenInterface = "loopback"
+        private set
+
+    @EncodeDefault
     var port = 5900
         private set
 

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/ListenIfAdapter.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/ListenIfAdapter.java
@@ -1,0 +1,159 @@
+/*
+ * DroidVNC-NG ListenIfAdapter, this is the adapter concrete implementation that is set to the Spinner in the main activity.
+ *
+ * Author: elluisian <elluisian@yandex.com>
+ *
+ * Copyright (C) 2024 Christian Beier.
+ *
+ * You can redistribute and/or modify this program under the terms of the
+ * GNU General Public License version 2 as published by the Free Software
+ * Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place Suite 330, Boston, MA 02111-1307, USA.
+ */
+package net.christianbeier.droidvnc_ng;
+
+
+import android.content.res.Resources;
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import android.widget.ArrayAdapter;
+import android.widget.TextView;
+import android.widget.Spinner;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+import net.christianbeier.droidvnc_ng.ifaceutils.NetIfData;
+import net.christianbeier.droidvnc_ng.ifaceutils.NetIfDataDecorator;
+import net.christianbeier.droidvnc_ng.ifaceutils.NetworkInterfaceTester;
+
+
+
+public class ListenIfAdapter extends ArrayAdapter<NetIfData> implements NetworkInterfaceTester.OnNetworkStateChangedListener {
+    // This adapter uses the ViewHolder pattern
+    private static class ViewHolder {
+        public TextView txtLabel;
+    }
+
+    // Data to be shown with the adapter
+    private List<NetIfDataDecorator> data;
+    private int dataSize;
+
+
+    // Some context data for "easy retrieval"
+    private Context mContext;
+    private LayoutInflater mInflater;
+
+
+    // UI related
+    private Handler handler;
+
+
+
+    public ListenIfAdapter(Context context) {
+        super(context, R.layout.spinner_row, R.id.spinner_text);
+
+        this.mContext = context;
+        this.mInflater = LayoutInflater.from(this.mContext);
+        this.handler = new Handler(Looper.getMainLooper());
+
+        NetworkInterfaceTester nit = NetworkInterfaceTester.getInstance(context);
+        nit.addOnNetworkStateChangedListener(this);
+        this.onNetworkStateChanged(nit);
+    }
+
+
+
+    public int getItemPositionByOptionId(String optionId) {
+        int i = 0;
+        for (NetIfDataDecorator nid : this.data) {
+            if (nid.getOptionId().equals(optionId)) {
+                return i;
+            }
+            i++;
+        }
+
+        return 1; // return loopback position as default
+    }
+
+
+
+    @Override
+    public View getDropDownView(int position, View convertView, ViewGroup parent) {
+        return this.handleViewRecreation(position, convertView, parent);
+    }
+
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        return this.handleViewRecreation(position, convertView, parent);
+    }
+
+
+    private View handleViewRecreation(int position, View convertView, ViewGroup parent) {
+        if (convertView == null) { // Check if view must be recreated using the famous ViewHolder pattern
+            convertView = this.mInflater.inflate(R.layout.spinner_row, parent, false);
+
+            ViewHolder vh = new ViewHolder();
+            vh.txtLabel = convertView.findViewById(R.id.spinner_text);
+            convertView.setTag(vh);
+        }
+
+        ViewHolder vh = (ViewHolder)convertView.getTag();
+        vh.txtLabel.setText(this.data.get(position).getName());
+
+        return convertView;
+    }
+
+
+
+    @Override
+    public NetIfData getItem(int position) {
+        if (0 <= position && position < this.getCount()) {
+            return this.data.get(position).getWrapped();
+        }
+        return null;
+    }
+
+
+
+    @Override
+    public int getCount() {
+        return this.dataSize;
+    }
+
+
+
+    public void onNetworkStateChanged(NetworkInterfaceTester nit) {
+        List<NetIfData> avNetIfs = nit.getAvailableNetIfs();
+
+        this.data = new ArrayList<>();
+        for (NetIfData nid : avNetIfs) {
+            this.data.add(new NetIfDataDefaultNameDecorator(nid, this.mContext));
+        }
+        this.dataSize = this.data.size();
+
+
+        // update Spinner
+        this.handler.post(new Runnable() {
+            public void run() {
+                ListenIfAdapter.this.notifyDataSetChanged();
+            }
+        });
+    }
+}

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/NetIfDataDefaultNameDecorator.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/NetIfDataDefaultNameDecorator.java
@@ -1,0 +1,55 @@
+/*
+ * DroidVNC-NG NetIfDataDefaultNameDecorator, a concrete decorator implementation for NetIfData.
+ * Given a NetIfData instance, this decorator shows the raw name of the referred NIC with a slight friendlier name for the "any" and "loopback" ones.
+ *
+ * Author: elluisian <elluisian@yandex.com>
+ *
+ * Copyright (C) 2024 Christian Beier (info@christianbeier.net>).
+ *
+ * You can redistribute and/or modify this program under the terms of the
+ * GNU General Public License version 2 as published by the Free Software
+ * Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place Suite 330, Boston, MA 02111-1307, USA.
+ */
+package net.christianbeier.droidvnc_ng;
+
+
+import android.content.Context;
+
+
+import net.christianbeier.droidvnc_ng.ifaceutils.NetIfData;
+import net.christianbeier.droidvnc_ng.ifaceutils.NetIfDataDecorator;
+
+
+
+public class NetIfDataDefaultNameDecorator extends NetIfDataDecorator {
+    public NetIfDataDefaultNameDecorator(NetIfData decorated, Context context) {
+        super(decorated, context);
+    }
+
+
+    public String getName() {
+        String raw = this.decorated.getName();
+        String display = null;
+
+        String optionId = this.decorated.getOptionId();
+        if (optionId.equals(NetIfData.ANY_OPTION_ID)) {
+            display = this.mContext.getResources().getString(R.string.main_activity_settings_listenif_spin_any);
+            raw = "0.0.0.0";
+
+        } else if (optionId.equals(NetIfData.LOOPBACK_OPTION_ID)) {
+            display = "Loopback";
+
+        }
+
+        return display == null ? raw : String.format("%s (%s)", display, raw);
+    }
+}

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/ifaceutils/INetIfData.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/ifaceutils/INetIfData.java
@@ -1,0 +1,46 @@
+/*
+ * DroidVNC-NG INetIfData, interface defining what is needed to properly gather all the data related to a particular NIC (Network interface card).
+ *
+ * Author: elluisian <elluisian@yandex.com>
+ *
+ * Copyright (C) 2024 Christian Beier (info@christianbeier.net>).
+ *
+ * You can redistribute and/or modify this program under the terms of the
+ * GNU General Public License version 2 as published by the Free Software
+ * Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place Suite 330, Boston, MA 02111-1307, USA.
+ */
+package net.christianbeier.droidvnc_ng.ifaceutils;
+
+
+import android.net.Network;
+
+
+import java.net.NetworkInterface;
+
+
+
+public interface INetIfData {
+    public static final String ANY_OPTION_ID = "any";
+    public static final String ANY_OPTION_ID_ADDR = "0.0.0.0";
+    public static final String LOOPBACK_OPTION_ID = "loopback";
+    public static final String LOOPBACK_OPTION_ID_ADDR_1 = "localhost";
+    public static final String LOOPBACK_OPTION_ID_ADDR_2 = "127.0.0.1";
+
+
+    public String getName();
+    public String getOptionId();
+    public boolean isLoopback();
+    public boolean isAny();
+
+    public NetworkInterface getNetworkInterface();
+    public Network getNetwork();
+}

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/ifaceutils/IfCollector.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/ifaceutils/IfCollector.java
@@ -1,0 +1,150 @@
+/*
+ * DroidVNC-NG IfCollector is a collector of NetIfData instances, these represent available NICs (Network Interface Card).
+ *
+ * Author: elluisian <elluisian@yandex.com>
+ *
+ * Copyright (C) 2024 Christian Beier (info@christianbeier.net>).
+ *
+ * You can redistribute and/or modify this program under the terms of the
+ * GNU General Public License version 2 as published by the Free Software
+ * Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place Suite 330, Boston, MA 02111-1307, USA.
+ */
+package net.christianbeier.droidvnc_ng.ifaceutils;
+
+
+import android.net.LinkProperties;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkRequest;
+import android.net.NetworkCapabilities;
+import android.content.Context;
+import android.util.Log;
+
+
+import java.net.SocketException;
+import java.net.NetworkInterface;
+import java.util.List;
+import java.util.ArrayList;
+
+
+import net.christianbeier.droidvnc_ng.Utils;
+
+
+
+public class IfCollector {
+    private static IfCollector COLL;
+
+    private NetIfData any;
+    private NetIfData loopback;
+    private List<NetIfData> nics;
+    private int nicsSize;
+
+
+
+    public static synchronized IfCollector getInstance() {
+        if (IfCollector.COLL == null) {
+            IfCollector.COLL = new IfCollector();
+        }
+
+        return IfCollector.COLL;
+    }
+
+
+    private IfCollector() {
+        this.any = NetIfData.getAny();
+
+        List<NetworkInterface> ifs = Utils.getAvailableNICs();
+        this.nics = new ArrayList<>();
+
+        for (NetworkInterface inf : ifs) {
+            NetIfData nid = NetIfData.getNetIf(inf);
+            if (!nid.isLoopback()) {
+                this.nics.add(nid);
+            } else {
+                this.loopback = nid;
+            }
+        }
+
+        this.nicsSize = this.nics.size();
+    }
+
+
+
+
+    public int searchForNetIfByOptionId(String optionId) {
+        int i = 0;
+        boolean found = false;
+        for (i = 0; !found && i < this.nicsSize; i++) {
+            if (optionId.equals(this.nics.get(i).getOptionId())) {
+                i--;
+                found = true;
+            }
+        }
+
+        return found ? i : -1;
+    }
+
+
+    public int searchForNetIfByNetwork(Network network) {
+        int i = 0;
+        boolean found = false;
+        for (i = 0; !found && i < this.nicsSize; i++) {
+            if (network.equals(this.nics.get(i).getNetwork())) {
+                i--;
+                found = true;
+            }
+        }
+
+        return found ? i : -1;
+    }
+
+
+
+    public void addNetIf(NetworkInterface iface, Network network) {
+        this.nics.add(NetIfData.getNetIf(iface, network));
+        this.nicsSize++;
+    }
+
+
+    public List<NetIfData> getEnabledNetIfs() {
+        List<NetIfData> ls = new ArrayList<>();
+
+        for (int i = 0; i < this.nicsSize; i++) {
+            NetIfData nid = this.nics.get(i);
+            if (nid.isEnabled()) {
+                ls.add(nid);
+            }
+        }
+
+        return ls;
+    }
+
+    public NetIfData getAny() {
+        return this.any;
+    }
+
+    public NetIfData getLoopback() {
+        return this.loopback;
+    }
+
+    public NetIfData getNetIf(int i) {
+        if (0 <= i && i < this.nicsSize) {
+            return this.nics.get(i);
+        }
+
+        return null;
+    }
+
+    public int getSize() {
+        return this.nicsSize;
+    }
+}

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/ifaceutils/NetIfData.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/ifaceutils/NetIfData.java
@@ -1,0 +1,166 @@
+/*
+ * DroidVNC-NG Concrete implementation of INetIfData.
+ *
+ * Author: elluisian <elluisian@yandex.com>
+ *
+ * Copyright (C) 2024 Christian Beier.
+ *
+ * You can redistribute and/or modify this program under the terms of the
+ * GNU General Public License version 2 as published by the Free Software
+ * Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place Suite 330, Boston, MA 02111-1307, USA.
+ */
+package net.christianbeier.droidvnc_ng.ifaceutils;
+
+
+import android.net.Network;
+
+
+import java.net.SocketException;
+import java.net.NetworkInterface;
+import java.util.ArrayList;
+
+
+
+public class NetIfData implements INetIfData {
+    private static NetIfData ANY_IF;
+
+    private NetworkInterface nic;
+    private Network net;
+    private String name;
+
+    private boolean enabled;
+    private boolean anyFlag;
+    private boolean loopbackFlag;
+
+
+
+
+    private NetIfData() {
+        this(null);
+    }
+
+    private NetIfData(NetworkInterface nic) {
+        this(nic, null);
+    }
+
+    private NetIfData(NetworkInterface nic, Network net) {
+        this.name = null;
+        this.anyFlag = false;
+        this.loopbackFlag = false;
+        this.nic = nic;
+        this.net = net;
+
+        try {
+            // Considering that when this.nic is null, it is highly probable that the referred interface is "any", consider it enabled
+            this.enabled = (nic == null) ? true : nic.isUp();
+
+        } catch(SocketException ex) {
+            this.enabled = false;
+
+        }
+
+        if (nic == null) {
+            this.name = NetIfData.ANY_OPTION_ID;
+            this.anyFlag = true;
+
+        } else {
+            this.name = this.nic.getName();
+            try {
+                this.loopbackFlag = this.nic.isLoopback();
+
+            } catch(SocketException ex) {
+                this.loopbackFlag = false;
+
+            }
+        }
+    }
+
+
+
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getOptionId() {
+        if (this.anyFlag) {
+            return NetIfData.ANY_OPTION_ID;
+
+        } else if (this.loopbackFlag) {
+            return NetIfData.LOOPBACK_OPTION_ID;
+
+        }
+
+        return this.getName();
+    }
+
+    public boolean isAny() {
+        return this.anyFlag;
+    }
+
+    public boolean isLoopback() {
+        return this.loopbackFlag;
+    }
+
+    public NetworkInterface getNetworkInterface() {
+        return this.nic;
+    }
+
+
+
+
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Network getNetwork() {
+        return this.net;
+    }
+
+    public void setNetwork(Network net) {
+        this.net = net;
+    }
+
+
+
+
+    public static NetIfData getAny() {
+        if (NetIfData.ANY_IF == null) {
+            NetIfData.ANY_IF = new NetIfData();
+        }
+        return NetIfData.ANY_IF;
+    }
+
+    public static NetIfData getNetIf(NetworkInterface nic) {
+        return new NetIfData(nic);
+    }
+
+    public static NetIfData getNetIf(NetworkInterface nic, Network net) {
+        return new NetIfData(nic, net);
+    }
+
+    public static boolean isOptionIdAny(String optionId) {
+        return (optionId.equals(NetIfData.ANY_OPTION_ID) ||
+            optionId.equals(NetIfData.ANY_OPTION_ID_ADDR));
+    }
+
+    public static boolean isOptionIdLoopback(String optionId) {
+        return (optionId.equals(NetIfData.LOOPBACK_OPTION_ID) ||
+            optionId.equals(NetIfData.LOOPBACK_OPTION_ID_ADDR_1) ||
+            optionId.equals(NetIfData.LOOPBACK_OPTION_ID_ADDR_2)
+        );
+    }
+}

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/ifaceutils/NetIfDataDecorator.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/ifaceutils/NetIfDataDecorator.java
@@ -1,0 +1,81 @@
+/*
+ * DroidVNC-NG NetIfDataDecorator, generic decorator pattern for NetIfData instances.
+ * This can be used to customize the name of a NIC as a means to add friendly names, if needed.
+ *
+ * Author: elluisian <elluisian@yandex.com>
+ *
+ * Copyright (C) 2024 Christian Beier (info@christianbeier.net>).
+ *
+ * You can redistribute and/or modify this program under the terms of the
+ * GNU General Public License version 2 as published by the Free Software
+ * Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place Suite 330, Boston, MA 02111-1307, USA.
+ */
+package net.christianbeier.droidvnc_ng.ifaceutils;
+
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.net.Network;
+
+
+import java.net.NetworkInterface;
+
+
+
+public abstract class NetIfDataDecorator implements INetIfData {
+    protected NetIfData decorated;
+    protected Context mContext;
+    protected Resources mResources;
+
+
+    public NetIfDataDecorator(NetIfData decorated) {
+        this(decorated, null);
+    }
+
+
+    public NetIfDataDecorator(NetIfData decorated, Context context) {
+        this.decorated = decorated;
+
+        if (context != null) {
+            this.mContext = context;
+            this.mResources = this.mContext.getResources();
+        }
+    }
+
+
+    public abstract String getName();
+
+
+    public final String getOptionId() {
+        return this.decorated.getOptionId();
+    }
+
+    public final boolean isAny() {
+        return this.decorated.isAny();
+    }
+
+    public final boolean isLoopback() {
+        return this.decorated.isLoopback();
+    }
+
+    public final NetworkInterface getNetworkInterface() {
+        return this.decorated.getNetworkInterface();
+    }
+
+    public final Network getNetwork() {
+        return this.decorated.getNetwork();
+    }
+
+    public final NetIfData getWrapped() {
+        return this.decorated;
+    }
+}

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/ifaceutils/NetworkInterfaceTester.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/ifaceutils/NetworkInterfaceTester.java
@@ -1,0 +1,228 @@
+/*
+ * DroidVNC-NG NetworkInterfaceTester, this is used by MainService/MainActivity used to detect whether network connections are lost or added.
+ *
+ * Author: elluisian <elluisian@yandex.com>
+ *
+ * Copyright (C) 2024 Christian Beier (info@christianbeier.net>).
+ *
+ * You can redistribute and/or modify this program under the terms of the
+ * GNU General Public License version 2 as published by the Free Software
+ * Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place Suite 330, Boston, MA 02111-1307, USA.
+ */
+package net.christianbeier.droidvnc_ng.ifaceutils;
+
+
+import android.net.LinkProperties;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkRequest;
+import android.net.NetworkCapabilities;
+import android.content.Context;
+import android.util.Log;
+
+
+import java.net.SocketException;
+import java.net.NetworkInterface;
+import java.util.List;
+import java.util.ArrayList;
+
+
+
+public class NetworkInterfaceTester extends ConnectivityManager.NetworkCallback {
+    public static final String TAG = "NetworkInterfaceTester";
+    private static NetworkInterfaceTester INSTANCE;
+
+
+
+    public synchronized static NetworkInterfaceTester getInstance(Context context) {
+        if (NetworkInterfaceTester.INSTANCE == null) {
+            NetworkInterfaceTester.INSTANCE = new NetworkInterfaceTester(context);
+        }
+        return NetworkInterfaceTester.INSTANCE;
+    }
+
+
+
+    public static interface OnNetworkStateChangedListener {
+        public void onNetworkStateChanged(NetworkInterfaceTester nit);
+    }
+
+
+
+    private IfCollector ifCollector;
+    private Context context;
+    private ConnectivityManager manager;
+    private List<OnNetworkStateChangedListener> listeners;
+
+
+
+    private NetworkInterfaceTester(Context context) {
+        this.ifCollector = IfCollector.getInstance();
+
+        this.listeners = new ArrayList<>();
+        this.manager = (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        this.manager.registerNetworkCallback(
+            new NetworkRequest.Builder()
+                .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+                .addTransportType(NetworkCapabilities.TRANSPORT_ETHERNET)
+                .addTransportType(NetworkCapabilities.TRANSPORT_VPN)
+                .removeCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN) // This is needed, otherwise, VPN start/stop is not detected
+                .build(),
+            this
+        );
+    }
+
+
+
+    public ArrayList<NetIfData> getAvailableNetIfs() {
+        ArrayList<NetIfData> ls = new ArrayList<>();
+
+        ls.add(this.ifCollector.getAny());
+        ls.add(this.ifCollector.getLoopback());
+        ls.addAll(this.ifCollector.getEnabledNetIfs());
+
+        return ls;
+    }
+
+
+
+
+    @Override
+    public void onAvailable(Network network) {
+        super.onAvailable(network);
+        int i = this.storeNetwork(network);
+
+        if (i != -1) {
+            NetIfData nid = this.ifCollector.getNetIf(i);
+            nid.setEnabled(true);
+            this.updateListener();
+        }
+    }
+
+
+    @Override
+    public void onLost(Network network) {
+        super.onLost(network);
+        int i = this.getFromNetwork(network);
+
+        if (i != -1) {
+            NetIfData nid = this.ifCollector.getNetIf(i);
+            nid.setEnabled(false);
+            this.updateListener();
+        }
+    }
+
+
+
+
+    @Override
+    public void onLosing(Network network, int maxMsToLive) {
+        Log.d(TAG, "onLosing " + network);
+    }
+
+    @Override
+    public void onBlockedStatusChanged(Network network, boolean blocked) {
+        Log.d(TAG, "onBlockedStatusChagned " + network);
+    }
+
+    @Override
+    public void onLinkPropertiesChanged(Network network, LinkProperties linkProperties) {
+        Log.d(TAG, "onLinkPropertiesChanged " + network);
+    }
+
+
+
+
+    /*
+     * The idea is simple: during onLost, LinkProperties attributes are lost
+     * inside Network, so, memorize a reference to the Network instance, this way,
+     * we'll be able to understand what exact interface was lost.
+     */
+    private int storeNetwork(Network network) {
+        LinkProperties prop = this.manager.getLinkProperties(network);
+        NetworkInterface iface = null;
+        try {
+            iface = NetworkInterface.getByName(prop.getInterfaceName());
+
+        } catch (SocketException ex) {
+            Log.d(TAG, "Socket exception has occurred, return -1");
+            return -1;
+        }
+
+        // No socket exception occurred, let's see if the interface is available
+        int i = this.ifCollector.searchForNetIfByOptionId(iface.getName());
+        if (i == -1) { // if not found, it means that it has been created recently, add to list
+            this.ifCollector.addNetIf(iface, network);
+
+        } else {
+            // Otherwise, the interface exists, replace network
+            NetIfData nid = this.ifCollector.getNetIf(i);
+            nid.setNetwork(network);
+        }
+
+        Log.d(TAG, "Added network " + iface.getName());
+
+        return i;
+    }
+
+
+    private int getFromNetwork(Network network) {
+        int i = this.ifCollector.searchForNetIfByNetwork(network);
+
+        if (i != -1) {
+            Log.d(TAG, "Removed network " + this.ifCollector.getNetIf(i).getOptionId());
+        } else {
+            Log.d(TAG, "Network to remove not found");
+        }
+
+        return i;
+    }
+
+
+
+
+    public void addOnNetworkStateChangedListener(OnNetworkStateChangedListener onscl) {
+        if (this.listeners.indexOf(onscl) == -1) {
+            this.listeners.add(onscl);
+        }
+    }
+
+
+    private void updateListener() {
+        for (OnNetworkStateChangedListener onscl : this.listeners) {
+            onscl.onNetworkStateChanged(this);
+        }
+    }
+
+
+    public boolean isIfEnabled(String listenIf) {
+        if (NetIfData.isOptionIdLoopback(listenIf) ||
+            NetIfData.isOptionIdAny(listenIf)) {
+            return true;
+        }
+
+        NetIfData loopback = this.ifCollector.getLoopback();
+        if (loopback.getName().equals(listenIf)) {
+            return true;
+        }
+
+
+        int i = this.ifCollector.searchForNetIfByOptionId(listenIf);
+        if (i != -1) {
+            NetIfData nid = this.ifCollector.getNetIf(i);
+            return nid.isEnabled();
+        }
+
+        return false;
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,6 +34,34 @@
                     android:layout_column="0"
                     android:padding="10dp"
                     android:hyphenationFrequency="full"
+                    android:text="@string/main_activity_settings_listening_interface" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_column="1"
+                    android:padding="10dp"
+                    android:text="@string/main_activity_colon" />
+
+                <Spinner
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_column="2"
+                    android:padding="10dp"
+                    android:layout_weight="3"
+                    android:id="@+id/settings_listening_interface"/>
+            </TableRow>
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:layout_column="0"
+                    android:padding="10dp"
                     android:text="@string/main_activity_settings_port" />
 
                 <TextView

--- a/app/src/main/res/layout/spinner_row.xml
+++ b/app/src/main/res/layout/spinner_row.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="10dp"
+            android:id="@+id/spinner_text"/>
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <string name="main_activity_title">droidVNC-NG Admin-Panel</string>
     <string name="main_activity_settings">Einstellungen</string>
+    <string name="main_activity_settings_listening_interface">Hörschnittstelle</string>
+    <string name="main_activity_settings_listenif_spin_any">Alle</string>
     <string name="main_activity_settings_port">Port</string>
     <string name="main_activity_settings_port_not_listening">Eingehende Verbindungen deaktiviert</string>
     <string name="main_activity_settings_password">Passwort</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <string name="main_activity_title">Administración de droidVNC-NG</string>
     <string name="main_activity_settings">Configuración</string>
+    <string name="main_activity_settings_listening_interface">Interfaz en escucha</string>
+    <string name="main_activity_settings_listenif_spin_any">Todas</string>
     <string name="main_activity_settings_port">Puerto</string>
     <string name="main_activity_settings_port_not_listening">Conexiones entrantes deshabilitadas</string>
     <string name="main_activity_settings_password">Contraseña</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <string name="main_activity_title">Administration de droidVNC-NG</string>
     <string name="main_activity_settings">Paramètres</string>
+    <string name="main_activity_settings_listening_interface">Interface en écoute</string>
+    <string name="main_activity_settings_listenif_spin_any">Toutes</string>
     <string name="main_activity_settings_port">Port</string>
     <string name="main_activity_settings_port_not_listening">Connexions d\'entrée désactivées</string>
     <string name="main_activity_settings_password">Mot de passe</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -2,6 +2,8 @@
     <string name="main_activity_title">Amministrazione di droidVNC-NG</string>
     <string name="main_activity_settings">Impostazioni</string>
     <string name="main_activity_settings_port">Porta</string>
+    <string name="main_activity_settings_listening_interface">Interfaccia in ascolto</string>
+    <string name="main_activity_settings_listenif_spin_any">Tutte</string>
     <string name="main_activity_settings_port_not_listening">Connessioni in entrata disabilitate</string>
     <string name="main_activity_settings_password">Password</string>
     <string name="main_activity_settings_access_key">Chiave di accesso API Intent</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <string name="main_activity_title">droidVNC-NG管理パネル</string>
     <string name="main_activity_settings">設定</string>
+    <string name="main_activity_settings_listening_interface">リスニングインターフェース</string>
+    <string name="main_activity_settings_listenif_spin_any">全て</string>
     <string name="main_activity_settings_port">ポート</string>
     <string name="main_activity_settings_port_not_listening">インバウンド接続は無効です</string>
     <string name="main_activity_settings_password">パスワード</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <string name="main_activity_title">Painel Administrativo do droidVNC-NG</string>
     <string name="main_activity_settings">Configurações</string>
+    <string name="main_activity_settings_listening_interface">Interface em escuta</string>
+    <string name="main_activity_settings_listenif_spin_any">Todas</string>
     <string name="main_activity_settings_port">Porta</string>
     <string name="main_activity_settings_port_not_listening">Conexões de entrada desativadas</string>
     <string name="main_activity_settings_password">Senha</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2,6 +2,8 @@
     <string name="main_activity_title">droidVNC-NG管理面板</string>
     <string name="main_activity_settings">设置</string>
     <string name="main_activity_settings_port">端口</string>
+    <string name="main_activity_settings_listening_interface">監聽介面</string>
+    <string name="main_activity_settings_listenif_spin_any">全部</string>
     <string name="main_activity_settings_port_not_listening">禁用传入连接</string>
     <string name="main_activity_settings_password">密码</string>
     <string name="main_activity_settings_access_key">意图 API 访问密钥</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,8 @@
     <string name="app_name" translatable="false">droidVNC-NG</string>
     <string name="main_activity_title">droidVNC-NG Admin Panel</string>
     <string name="main_activity_settings">Settings</string>
+    <string name="main_activity_settings_listening_interface">Listening Interface</string>
+    <string name="main_activity_settings_listenif_spin_any">Any</string>
     <string name="main_activity_settings_port">Port</string>
     <string name="main_activity_settings_port_not_listening">Inbound connections disabled</string>
     <string name="main_activity_settings_password">Password</string>


### PR DESCRIPTION
## UPDATE, Monday, February 17th 2025

This commit implements the feature requests reported on the issues #43 and #227.
It is now possible to make the server listen only on certain interfaces, instead of all of them.
This not only increases security, but it also allows the "typical SSH usage", that is, SSH server + public key authentication + local port forwarding + VNC server listening on localhost.



## OLD MESSAGE

When applied, this commit tries to implement the feature requests reported on the issues #43 and #227. Basically, with this, it is now possible to make the server listen only on certain addresses. This increases security and allows the typical "SSH usage", that is, SSH + publickey auth + local port forwarding + VNC listening on localhost only.

To achieve this:

- on droidvnc-ng.c, vncServerStart was modified in order to provide a further "jstring listenIf" parameter. It uses rfbScreenInfo*'s listenInterface property.

- A TableRow was added in order to allow users to input the desired address to use ("Listening Address").

- On droidvnc-ng.c, the method vncServerGetListenInterface was introduced in order to track if the server is currenctly set to listen to 0.0.0.0 or not (this is used to properly show what addresses are available to use on the UI).

Please note that, if an invalid address/host is set, by default, it is assumed the address 0.0.0.0 is requested.