### PR TITLE
Refactor MainService to prevent unnecessary activity starts

### DIFF
--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainService.java
@@ -438,6 +438,10 @@ public class MainService extends Service {
                 }).start();
             } else {
                 stopSelfByUs();
+                Intent answer = new Intent(ACTION_CONNECT_REVERSE);
+                answer.putExtra(EXTRA_REQUEST_ID, intent.getStringExtra(EXTRA_REQUEST_ID));
+                answer.putExtra(EXTRA_REQUEST_SUCCESS, false);
+                sendBroadcastToOthersAndUs(answer);
             }
 
             return START_NOT_STICKY;
@@ -466,6 +470,10 @@ public class MainService extends Service {
                 }).start();
             } else {
                 stopSelfByUs();
+                Intent answer = new Intent(ACTION_CONNECT_REPEATER);
+                answer.putExtra(EXTRA_REQUEST_ID, intent.getStringExtra(EXTRA_REQUEST_ID));
+                answer.putExtra(EXTRA_REQUEST_SUCCESS, false);
+                sendBroadcastToOthersAndUs(answer);
             }
 
             return START_NOT_STICKY;
@@ -475,6 +483,10 @@ public class MainService extends Service {
         if(!vncIsActive()) {
             stopSelfByUs();
         }
+        Intent answer = new Intent(intent.getAction());
+        answer.putExtra(EXTRA_REQUEST_ID, intent.getStringExtra(EXTRA_REQUEST_ID));
+        answer.putExtra(EXTRA_REQUEST_SUCCESS, false);
+        sendBroadcastToOthersAndUs(answer);
 
         return START_NOT_STICKY;
     }

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/NotificationRequestActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/NotificationRequestActivity.java
@@ -18,7 +18,7 @@ public class NotificationRequestActivity extends AppCompatActivity {
 
     private static final String TAG = "NotificationRequestActivity";
     private static final int REQUEST_POST_NOTIFICATION = 45;
-    private static final String PREFS_KEY_POST_NOTIFICATION_PERMISSION_ASKED_BEFORE = "post_notification_permission_asked_before";
+    public static final String PREFS_KEY_POST_NOTIFICATION_PERMISSION_ASKED_BEFORE = "post_notification_permission_asked_before";
 
 
     @Override

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/WriteStorageRequestActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/WriteStorageRequestActivity.java
@@ -38,7 +38,7 @@ public class WriteStorageRequestActivity extends AppCompatActivity {
 
     private static final String TAG = "WriteStorageRequestActivity";
     private static final int REQUEST_WRITE_STORAGE = 44;
-    private static final String PREFS_KEY_PERMISSION_ASKED_BEFORE = "write_storage_permission_asked_before";
+    public static final String PREFS_KEY_PERMISSION_ASKED_BEFORE = "write_storage_permission_asked_before";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
I was about to automate the session startup with my DPC application.
My device is in Lock Task Mode, so starting activities is prohibited.
This cleans up the startup process so that in case all permissions are granted no activities have to be launched.

There should be no logic change. Just moving the code in separate methods
and directly check the permission condition in the service before starting the activity to request it.

Most of the time this will save the overhead of jumping between activities and service
as permissions are only requested the first time.
This helps when automating the start process of a session.

Also send a response to the caller in some failure cases.