### PR TITLE
Implement App Restrictions to load defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ An example `defaults.json` with completely new defaults (not all entries need to
 }
 ```
 
+#### Pre-seed Preferences via Managed App Restrictions
+If you are using a device owner app, you can also pre-seed the preferences via managed app restrictions. 
+The same keys as in the JSON file above can be used.
+
+See: https://developer.android.com/work/managed-configurations
+
+> NOTE: Updates to app restrictions are only applied when the service restarts.
+
 ### Remote Control via the Intent Interface
 
 droidVNC-NG features a remote control interface by means of Intents. This allows starting the VNC

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,10 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
+        <meta-data
+            android:name="android.content.APP_RESTRICTIONS"
+            android:resource="@xml/app_config" />
+
         <receiver android:name=".OnBootReceiver"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,4 +70,6 @@
     <string name="share_activtiy_server_not_running">Not shared text, server is not running.</string>
     <string name="share_activtiy_no_clients_connected">Not shared text, no clients connected.</string>
     <string name="share_activtiy_shared_successfully">Shared text to clipboards of all connected clients.</string>
+    <string name="settings_port_reverse" translatable="false">Reverse Port</string>
+    <string name="settings_port_repeater" translatable="false">Repeater Port</string>
 </resources>

--- a/app/src/main/res/xml/app_config.xml
+++ b/app/src/main/res/xml/app_config.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<restrictions xmlns:android="http://schemas.android.com/apk/res/android">
+    <restriction
+        android:defaultValue="5900"
+        android:key="port"
+        android:restrictionType="integer"
+        android:title="@string/main_activity_settings_port" />
+
+    <restriction
+        android:defaultValue="5500"
+        android:key="portReverse"
+        android:restrictionType="integer"
+        android:title="@string/settings_port_reverse" />
+
+    <restriction
+        android:defaultValue="5500"
+        android:key="portRepeater"
+        android:restrictionType="integer"
+        android:title="@string/settings_port_repeater" />
+
+    <restriction
+        android:defaultValue="0.0"
+        android:key="scaling"
+        android:restrictionType="string"
+        android:title="@string/main_activity_settings_scaling" /> <!-- NOTE: float not supported, so we use string -->
+
+    <restriction
+        android:defaultValue="false"
+        android:key="viewOnly"
+        android:restrictionType="bool"
+        android:title="@string/main_activity_settings_view_only" />
+
+    <restriction
+        android:defaultValue="false"
+        android:key="showPointers"
+        android:restrictionType="bool"
+        android:title="@string/main_activity_settings_show_pointers" />
+
+    <restriction
+        android:defaultValue="true"
+        android:key="fileTransfer"
+        android:restrictionType="bool"
+        android:title="@string/main_activity_settings_file_transfer" />
+
+    <restriction
+        android:defaultValue=""
+        android:key="password"
+        android:restrictionType="string"
+        android:title="@string/main_activity_settings_password" />
+
+    <restriction
+        android:defaultValue=""
+        android:key="accessKey"
+        android:restrictionType="string"
+        android:title="@string/main_activity_settings_access_key" />
+
+    <restriction
+        android:defaultValue="true"
+        android:key="startOnBoot"
+        android:restrictionType="bool"
+        android:title="@string/main_activity_settings_start_on_boot" />
+
+    <restriction
+        android:defaultValue="0"
+        android:key="startOnBootDelay"
+        android:restrictionType="integer"
+        android:title="@string/main_activity_settings_start_on_boot_delay" />
+
+</restrictions>


### PR DESCRIPTION
App Restrictions are a way to configure an App by a mobile device management application.
This lets admins set defaults without requiring a rooted phone (#291).

See: https://developer.android.com/reference/android/content/RestrictionsManager

This implements feature request: #197

It first tries to load defaults from app restriction only if those are not available it tries loading the json file.