### PR TITLE
bug_244: fix pre-Android 14 Google TV DPAD input handling of text v.s…

### DIFF
--- a/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
@@ -37,6 +37,7 @@ import android.view.accessibility.AccessibilityEvent;
 import android.view.ViewConfiguration;
 import android.graphics.Path;
 import android.view.accessibility.AccessibilityNodeInfo;
+import android.view.accessibility.AccessibilityWindowInfo;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
@@ -46,7 +47,6 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import android.view.accessibility.AccessibilityWindowInfo;
 
 @SuppressLint("AccessibilityPolicy")
 public class InputService extends AccessibilityService {
@@ -629,6 +629,7 @@ public class InputService extends AccessibilityService {
 				Get current keyboard focus node for input context's display.
 			 */
 			AccessibilityNodeInfo currentFocusNode = instance.mKeyboardFocusNodes.get(inputContext.getDisplayId());
+			// refresh() is important to load the represented view's current text into the node
 			if (currentFocusNode != null) {
 				currentFocusNode.refresh();
 			}


### PR DESCRIPTION
RCA:
For Android devices older than version 14, the application was attempting to handle DPAD (remote control directional pad) inputs by moving a text cursor, which is incorrect for navigating a TV user interface.

To fix this, I made the following changes to app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java:

Added context-aware navigation: When the user has a text field (including standard EditText and TextView) in focus, the D-pad now functions as a text cursor.
View Navigation: If the focused element is not a text field, the D-pad retains its original behavior, shifting the focus between different UI components.

Also attempts to attain focus when user presses on DPAD, and there is no focus available. This allows user to have better control in the edge-case where device doesn't consider any particular view in focus.


On a TV Device (running Android < 14):
Effect: This is a critical fix. DPAD navigation with a remote control will now work correctly, allowing users to navigate between buttons, menus, and other UI elements. The application is now usable on these devices.
Risk: None. This change corrects the behavior to match user expectations for a TV app.
On a non-TV Device (Phone/Tablet, running Android < 14):
Effect: This change is also an improvement. If a user has an external keyboard connected, the arrow keys will now properly navigate between focusable elements in the app (like buttons or input fields), which is standard behavior. The previous text-cursor logic was less useful and only worked inside text boxes.
Risk: Very low. The new behavior is more consistent with standard Android keyboard navigation and is unlikely to cause any issues.

On Any Device (TV or non-TV, running Android 14+):
Effect: None. These devices use a more modern input handling method that was already working correctly. The code I modified is part of a fallback for older Android versions and is not executed on newer ones.
Risk: None.

Video of test run on Sony TV running Android 9:
https://drive.google.com/file/d/1gjjfkjSKLxkCvSKM51FbqrCtp24S7ygE/view?usp=sharing