### PR TITLE
Block non-local VNC connections on Wi-Fi

### DIFF
--- a/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/MainActivity.java
@@ -32,6 +32,7 @@ import android.content.res.Resources;
 import android.net.ConnectivityManager;
 import android.net.LinkProperties;
 import android.net.Network;
+import android.net.NetworkCapabilities;
 import android.net.NetworkRequest;
 import android.net.Uri;
 import android.os.Build;
@@ -207,6 +208,14 @@ public class MainActivity extends AppCompatActivity {
                                 // stays at default reverse port
                             }
                         }
+                        if (isOnWifi() && isNonLocalHost(host)) {
+                            new AlertDialog.Builder(MainActivity.this)
+                                    .setTitle(R.string.error)
+                                    .setMessage(R.string.main_activity_wifi_block_message)
+                                    .setPositiveButton(android.R.string.ok, null)
+                                    .show();
+                            return;
+                        }
                         Log.d(TAG, "reverse vnc " + host + ":" + port);
                         mLastMainServiceRequestId = UUID.randomUUID().toString();
                         mLastReverseHost = host;
@@ -294,6 +303,14 @@ public class MainActivity extends AppCompatActivity {
                         // sanity-check
                         if (host.isEmpty() || repeaterId.isEmpty()) {
                             Toast.makeText(MainActivity.this, getString(R.string.main_activity_repeater_vnc_input_missing), Toast.LENGTH_LONG).show();
+                            return;
+                        }
+                        if (isOnWifi() && isNonLocalHost(host)) {
+                            new AlertDialog.Builder(MainActivity.this)
+                                    .setTitle(R.string.error)
+                                    .setMessage(R.string.main_activity_wifi_block_message)
+                                    .setPositiveButton(android.R.string.ok, null)
+                                    .show();
                             return;
                         }
                         // done
@@ -914,6 +931,23 @@ public class MainActivity extends AppCompatActivity {
         } else {
             mAddress.post(() -> mAddress.setText(R.string.main_activity_not_listening));
         }
+    }
+
+    private boolean isOnWifi() {
+        ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+        Network activeNetwork = cm.getActiveNetwork();
+        if (activeNetwork == null) return false;
+        NetworkCapabilities caps = cm.getNetworkCapabilities(activeNetwork);
+        return caps != null && caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI);
+    }
+
+    static boolean isNonLocalHost(String host) {
+        if (host.matches("^10\\.\\d+\\.\\d+\\.\\d+$")) return false;
+        if (host.matches("^172\\.(1[6-9]|2\\d|3[01])\\.\\d+\\.\\d+$")) return false;
+        if (host.matches("^192\\.168\\.\\d+\\.\\d+$")) return false;
+        if (host.matches("^127\\.\\d+\\.\\d+\\.\\d+$")) return false;
+        if (host.equalsIgnoreCase("localhost")) return false;
+        return true;
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="main_activity_repeater_vnc_fail">Connection to %1$s with ID %2$s failed</string>
     <string name="main_activity_repeater_vnc_input_missing">Host and/or ID missing</string>
     <string name="main_activity_reconnect_tries_hint">Max. reconnect tries</string>
+    <string name="main_activity_wifi_block_message">Connection blocked. Disconnect from your Wi-Fi in order to use domain names or non-local IPs.</string>
     <string name="main_activity_special_key_reference">From a VNC viewer, <b>Ctrl-Shift-Esc</b> triggers \'Recent Apps\' overview, <b>Home/Pos1</b> acts as Home button, <b>End</b> acts as Power button, <b>Escape</b> acts as Back button, <b>Ctrl-Alt-PageUp/PageDown</b> change audio volume.</string>
     <string name="main_activity_about">This is droidVNC-NG %1$s. Please note that more features are still being added to droidVNC-NG. You can report any issues and feature requests at https://github.com/bk138/droidVNC-NG/issues</string>
     <string name="main_activity_survey_button">Provide Feedback</string>

--- a/app/src/test/java/net/christianbeier/droidvnc_ng/MainActivityTest.java
+++ b/app/src/test/java/net/christianbeier/droidvnc_ng/MainActivityTest.java
@@ -1,0 +1,35 @@
+package net.christianbeier.droidvnc_ng;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MainActivityTest {
+
+    @Test
+    public void isNonLocalHost_privateRfc1918_returnsFalse() {
+        assertFalse(MainActivity.isNonLocalHost("10.0.0.1"));
+        assertFalse(MainActivity.isNonLocalHost("10.255.255.255"));
+        assertFalse(MainActivity.isNonLocalHost("172.16.0.1"));
+        assertFalse(MainActivity.isNonLocalHost("172.31.255.255"));
+        assertFalse(MainActivity.isNonLocalHost("192.168.0.1"));
+        assertFalse(MainActivity.isNonLocalHost("192.168.1.100"));
+    }
+
+    @Test
+    public void isNonLocalHost_loopback_returnsFalse() {
+        assertFalse(MainActivity.isNonLocalHost("127.0.0.1"));
+        assertFalse(MainActivity.isNonLocalHost("127.1.2.3"));
+        assertFalse(MainActivity.isNonLocalHost("localhost"));
+        assertFalse(MainActivity.isNonLocalHost("LOCALHOST"));
+    }
+
+    @Test
+    public void isNonLocalHost_publicIpOrDomain_returnsTrue() {
+        assertTrue(MainActivity.isNonLocalHost("8.8.8.8"));
+        assertTrue(MainActivity.isNonLocalHost("1.1.1.1"));
+        assertTrue(MainActivity.isNonLocalHost("203.0.113.1"));
+        assertTrue(MainActivity.isNonLocalHost("example.com"));
+        assertTrue(MainActivity.isNonLocalHost("my.viewer.net"));
+    }
+}


### PR DESCRIPTION
Fixes #354

Blocks non-local VNC connections when on Wi-Fi, applies to both reverse and repeater modes. Users see an error dialog if they try to connect anyway. Includes tests for the new behavior.