### PR TITLE
Add monochrome adaptive icon

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+      android:width="108dp"
+      android:height="108dp"
+      android:viewportWidth="108"
+      android:viewportHeight="108">
+      <group
+                android:scaleX="0.6"
+                android:scaleY="0.6"
+                android:translateX="13.362"
+                android:translateY="13.362">
+                <path
+                              android:fillColor="@android:color/white"
+                              android:pathData="M120.75,67.73A51.02,51.02 0,0 0,69.9 16.72v-0H69.8,14.72v29.96h55.18v-0.01a21.08,21.08 0,0 1,20.91 21.07,21.08 21.08,0 0,1 -20.91,21.07v-0.02H14.72v29.96h55.08v0a51.02,51.02 0,0 0,0.01 -0h0.09v-0A51.02,51.02 0,0 0,120.75 67.73Z"/>
+      </group>
+</vector>

--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -4,10 +4,10 @@
       android:viewportWidth="108"
       android:viewportHeight="108">
       <group
-                android:scaleX="0.6"
-                android:scaleY="0.6"
-                android:translateX="13.362"
-                android:translateY="13.362">
+                android:scaleX="0.72"
+                android:scaleY="0.72"
+                android:translateX="5.232"
+                android:translateY="5.232">
                 <path
                               android:fillColor="@android:color/white"
                               android:pathData="M120.75,67.73A51.02,51.02 0,0 0,69.9 16.72v-0H69.8,14.72v29.96h55.18v-0.01a21.08,21.08 0,0 1,20.91 21.07,21.08 21.08,0 0,1 -20.91,21.07v-0.02H14.72v29.96h55.08v0a51.02,51.02 0,0 0,0.01 -0h0.09v-0A51.02,51.02 0,0 0,120.75 67.73Z"/>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@color/ic_launcher_background"/>
-    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+        <background android:drawable="@color/ic_launcher_background"/>
+        <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+        <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@color/ic_launcher_background"/>
-    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+        <background android:drawable="@color/ic_launcher_background"/>
+        <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+        <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
 </adaptive-icon>


### PR DESCRIPTION
Adds a monochrome layer to the adaptive launcher icon following Android 13+ guidelines for themed icons. This uses the existing vector logo scaled appropriately for the monochrome layer.