### PR TITLE
input: restore pointer clicks across accessibility rebinds

### DIFF
--- a/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
@@ -36,6 +36,7 @@ import android.view.View;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.ViewConfiguration;
 import android.graphics.Path;
+import android.graphics.Rect;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.accessibility.AccessibilityWindowInfo;
 
@@ -75,6 +76,9 @@ public class InputService extends AccessibilityService {
 	private static class InputContext {
 		// pointer-related
 		boolean isButtonOneDown;
+		int pointerDownX;
+		int pointerDownY;
+		boolean pointerMoved;
 		Path path = new Path();
 		GestureDescription.StrokeDescription stroke;
 		long lastGestureStartTime;
@@ -312,21 +316,38 @@ public class InputService extends AccessibilityService {
 			    left mouse button
 			 */
 
+			boolean buttonOneDown = (buttonMask & (1 << 0)) != 0;
+			boolean buttonOneWasDown = inputContext.isButtonOneDown;
+
 			// down, was up
-			if ((buttonMask & (1 << 0)) != 0 && !inputContext.isButtonOneDown) {
+			if (buttonOneDown && !buttonOneWasDown) {
 				inputContext.isButtonOneDown = true;
+				inputContext.pointerDownX = x;
+				inputContext.pointerDownY = y;
+				inputContext.pointerMoved = false;
 				instance.startStroke(inputContext, x, y);
 			}
 
 			// down, was down
-			if ((buttonMask & (1 << 0)) != 0 && inputContext.isButtonOneDown) {
-				instance.continueStroke(inputContext, x, y);
+			if (buttonOneDown && buttonOneWasDown) {
+				int touchSlop = ViewConfiguration.get(instance).getScaledTouchSlop();
+				if (Math.abs(x - inputContext.pointerDownX) > touchSlop
+						|| Math.abs(y - inputContext.pointerDownY) > touchSlop) {
+					inputContext.pointerMoved = true;
+				}
+				if (inputContext.pointerMoved) {
+					instance.continueStroke(inputContext, x, y);
+				}
 			}
 
 			// up, was down
-			if ((buttonMask & (1 << 0)) == 0 && inputContext.isButtonOneDown) {
+			if (!buttonOneDown && buttonOneWasDown) {
 				inputContext.isButtonOneDown = false;
-				instance.endStroke(inputContext, x, y);
+				if (inputContext.pointerMoved) {
+					instance.endStroke(inputContext, x, y);
+				} else {
+					instance.clickAtCoordinates(inputContext, x, y);
+				}
 			}
 
 
@@ -1105,6 +1126,70 @@ public class InputService extends AccessibilityService {
 		// Docs says: Any gestures currently in progress, whether from the user, this service, or another service, will be cancelled.
 		// But at least on API level 32, setting different display ids with the builder allows for parallel input.
 		dispatchGesture(builder.build(), null, null);
+	}
+
+	/**
+	 * Some Android TV builds do not route injected tap gestures to applications. Prefer clicking
+	 * the deepest accessibility node at the pointer coordinates, then fall back to a standalone
+	 * tap for surfaces that do not expose a clickable accessibility node.
+	 */
+	private void clickAtCoordinates(InputContext inputContext, int x, int y) {
+		if (!performAccessibleClickAt(inputContext.getDisplayId(), x, y)) {
+			mMainHandler.post(() ->
+					dispatchGesture(
+							createClick(inputContext, x, y, Math.max(1, ViewConfiguration.getTapTimeout())),
+							inputContext.gestureCallback,
+							null
+					)
+			);
+		}
+	}
+
+	private boolean performAccessibleClickAt(int displayId, int x, int y) {
+		for (AccessibilityWindowInfo window : getWindows()) {
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && window.getDisplayId() != displayId) {
+				continue;
+			}
+
+			AccessibilityNodeInfo root = window.getRoot();
+			if (root == null) {
+				continue;
+			}
+
+			try {
+				if (performAccessibleClickAt(root, x, y)) {
+					return true;
+				}
+			} finally {
+				root.recycle();
+			}
+		}
+		return false;
+	}
+
+	private boolean performAccessibleClickAt(AccessibilityNodeInfo node, int x, int y) {
+		Rect bounds = new Rect();
+		node.getBoundsInScreen(bounds);
+		if (!bounds.contains(x, y) || !node.isVisibleToUser() || !node.isEnabled()) {
+			return false;
+		}
+
+		// Children are more specific than their containers, especially for WebView content.
+		for (int index = node.getChildCount() - 1; index >= 0; index--) {
+			AccessibilityNodeInfo child = node.getChild(index);
+			if (child == null) {
+				continue;
+			}
+			try {
+				if (performAccessibleClickAt(child, x, y)) {
+					return true;
+				}
+			} finally {
+				child.recycle();
+			}
+		}
+
+		return node.isClickable() && node.performAction(AccessibilityNodeInfo.ACTION_CLICK);
 	}
 
 

--- a/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
@@ -84,6 +84,10 @@ public class InputService extends AccessibilityService {
 		long lastGestureStartTime;
 		GestureCallback gestureCallback = new GestureCallback();
 		InputPointerView pointerView;
+		boolean withPointer;
+		float pointerRed;
+		float pointerGreen;
+		float pointerBlue;
 		// keyboard-related
 		boolean isKeyCtrlDown;
 		boolean isKeyAltDown;
@@ -103,22 +107,37 @@ public class InputService extends AccessibilityService {
 			this.displayId = displayId;
 			// and if there is a pointer, recreate it with the new display id
 			if(pointerView != null) {
-				pointerView.removeView();
-				pointerView = new InputPointerView(
-						instance,
-						displayId,
-						pointerView.getRed(),
-						pointerView.getGreen(),
-						pointerView.getBlue()
-				);
-				pointerView.addView();
+				detachPointerView();
+				attachPointerView();
 			}
+		}
+
+		void attachPointerView() {
+			if (!withPointer || pointerView != null || instance == null) {
+				return;
+			}
+			pointerView = new InputPointerView(
+					instance,
+					displayId,
+					pointerRed,
+					pointerGreen,
+					pointerBlue
+			);
+			pointerView.addView();
+		}
+
+		void detachPointerView() {
+			if (pointerView == null) {
+				return;
+			}
+			pointerView.removeView();
+			pointerView = null;
 		}
 	}
 
 	private static final String TAG = "InputService";
 
-	private static InputService instance;
+	private static volatile InputService instance;
 	/**
 	 * Scaling factor that's applied to incoming pointer events by dividing coordinates by
 	 * the given factor.
@@ -132,7 +151,9 @@ public class InputService extends AccessibilityService {
 
 	private Handler mMainHandler;
 
-	private final Map<Long, InputContext> mInputContexts = new ConcurrentHashMap<>();
+	// The AccessibilityService can be rebound while VNC clients remain connected. Keep their
+	// input state for the process lifetime and recreate service-owned pointer views on rebind.
+	private static final Map<Long, InputContext> mInputContexts = new ConcurrentHashMap<>();
 	/**
 	 * System keyboard input foci, display-specific starting on Android 10 (really 11 in higher layers),
 	 * see <a href="https://source.android.com/docs/core/display/multi_display/displays#focus">Android docs</a>
@@ -190,12 +211,18 @@ public class InputService extends AccessibilityService {
 		isInputEnabled = PreferenceManager.getDefaultSharedPreferences(this).getBoolean(Constants.PREFS_KEY_INPUT_LAST_ENABLED, !new Defaults(this).getViewOnly());
 		scaling = PreferenceManager.getDefaultSharedPreferences(this).getFloat(Constants.PREFS_KEY_SERVER_LAST_SCALING, new Defaults(this).getScaling());
 		mMainHandler = new Handler(instance.getMainLooper());
+		for (InputContext inputContext : mInputContexts.values()) {
+			mMainHandler.post(inputContext::attachPointerView);
+		}
 		Log.i(TAG, "onServiceConnected");
 	}
 
 	@Override
 	public void onDestroy() {
 		super.onDestroy();
+		for (InputContext inputContext : mInputContexts.values()) {
+			inputContext.detachPointerView();
+		}
 		instance = null;
 		Log.i(TAG, "onDestroy");
 	}
@@ -248,21 +275,16 @@ public class InputService extends AccessibilityService {
 			int displayId = Display.DEFAULT_DISPLAY;
 			InputContext inputContext = new InputContext();
 			inputContext.setDisplayId(displayId);
+			inputContext.withPointer = withPointer;
 			if(withPointer) {
 				// run this on UI thread (use main handler as view is not yet added)
-                int inputContextsSize = instance.mInputContexts.size();
-                instance.mMainHandler.post(() -> {
-                    inputContext.pointerView = new InputPointerView(
-                            instance,
-                            displayId,
-                            0.4f * ((inputContextsSize + 1) % 3),
-                            0.2f * ((inputContextsSize + 1) % 5),
-                            1.0f * ((inputContextsSize + 1) % 2)
-                    );
-                    inputContext.pointerView.addView();
-               });
+				int inputContextsSize = mInputContexts.size();
+				inputContext.pointerRed = 0.4f * ((inputContextsSize + 1) % 3);
+				inputContext.pointerGreen = 0.2f * ((inputContextsSize + 1) % 5);
+				inputContext.pointerBlue = 1.0f * ((inputContextsSize + 1) % 2);
+				instance.mMainHandler.post(inputContext::attachPointerView);
 			}
-			instance.mInputContexts.put(client, inputContext);
+			mInputContexts.put(client, inputContext);
 		} catch (Exception e) {
 			Log.e(TAG, "addClient: " + e);
 		}
@@ -272,12 +294,12 @@ public class InputService extends AccessibilityService {
 	public static void removeClient(long client) {
 		// NB runs on a worker thread!
 		try {
-			InputContext inputContext = instance.mInputContexts.get(client);
+			InputContext inputContext = mInputContexts.get(client);
 			if(inputContext != null && inputContext.pointerView != null) {
 				// run this on UI thread
 				inputContext.pointerView.post(inputContext.pointerView::removeView);
 			}
-			instance.mInputContexts.remove(client);
+			mInputContexts.remove(client);
 		} catch (Exception e) {
 			Log.e(TAG, "removeClient: " + e);
 		}
@@ -291,8 +313,17 @@ public class InputService extends AccessibilityService {
 			return;
 		}
 
+		InputService connectedInstance = instance;
+		if (connectedInstance == null) {
+			int pendingButtonMask = buttonMask;
+			int pendingX = x;
+			int pendingY = y;
+			runWhenConnected(() -> onPointerEvent(pendingButtonMask, pendingX, pendingY, client));
+			return;
+		}
+
 		try {
-			InputContext inputContext = instance.mInputContexts.get(client);
+			InputContext inputContext = mInputContexts.get(client);
 
 			if(inputContext == null) {
 				throw new IllegalStateException("Client " + client + " was not added or is already removed");
@@ -325,7 +356,7 @@ public class InputService extends AccessibilityService {
 				inputContext.pointerDownX = x;
 				inputContext.pointerDownY = y;
 				inputContext.pointerMoved = false;
-				instance.startStroke(inputContext, x, y);
+				connectedInstance.startStroke(inputContext, x, y);
 			}
 
 			// down, was down
@@ -336,7 +367,7 @@ public class InputService extends AccessibilityService {
 					inputContext.pointerMoved = true;
 				}
 				if (inputContext.pointerMoved) {
-					instance.continueStroke(inputContext, x, y);
+					connectedInstance.continueStroke(inputContext, x, y);
 				}
 			}
 
@@ -344,36 +375,36 @@ public class InputService extends AccessibilityService {
 			if (!buttonOneDown && buttonOneWasDown) {
 				inputContext.isButtonOneDown = false;
 				if (inputContext.pointerMoved) {
-					instance.endStroke(inputContext, x, y);
+					connectedInstance.endStroke(inputContext, x, y);
 				} else {
-					instance.clickAtCoordinates(inputContext, x, y);
+					connectedInstance.clickAtCoordinates(inputContext, x, y);
 				}
 			}
 
 
 			// right mouse button
 			if ((buttonMask & (1 << 2)) != 0) {
-				instance.longPress(inputContext, x, y);
+				connectedInstance.longPress(inputContext, x, y);
 			}
 
 			// scroll up
 			if ((buttonMask & (1 << 3)) != 0) {
 
 				DisplayMetrics displayMetrics = new DisplayMetrics();
-				WindowManager wm = (WindowManager) instance.getApplicationContext().getSystemService(Context.WINDOW_SERVICE);
+				WindowManager wm = (WindowManager) connectedInstance.getApplicationContext().getSystemService(Context.WINDOW_SERVICE);
 				wm.getDefaultDisplay().getRealMetrics(displayMetrics);
 
-				instance.scroll(inputContext, x, y, -displayMetrics.heightPixels / 2);
+				connectedInstance.scroll(inputContext, x, y, -displayMetrics.heightPixels / 2);
 			}
 
 			// scroll down
 			if ((buttonMask & (1 << 4)) != 0) {
 
 				DisplayMetrics displayMetrics = new DisplayMetrics();
-				WindowManager wm = (WindowManager) instance.getApplicationContext().getSystemService(Context.WINDOW_SERVICE);
+				WindowManager wm = (WindowManager) connectedInstance.getApplicationContext().getSystemService(Context.WINDOW_SERVICE);
 				wm.getDefaultDisplay().getRealMetrics(displayMetrics);
 
-				instance.scroll(inputContext, x, y, displayMetrics.heightPixels / 2);
+				connectedInstance.scroll(inputContext, x, y, displayMetrics.heightPixels / 2);
 			}
 		} catch (Exception e) {
 			// instance probably null
@@ -388,12 +419,17 @@ public class InputService extends AccessibilityService {
 			return;
 		}
 
+		if (!isConnected()) {
+			runWhenConnected(() -> onKeyEvent(down, keysym, client));
+			return;
+		}
+
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "onKeyEvent: keysym 0x" + Long.toHexString(keysym) + " down " + down + " by client " + client);
         }
 
 		try {
-			InputContext inputContext = instance.mInputContexts.get(client);
+			InputContext inputContext = mInputContexts.get(client);
 
 			if(inputContext == null) {
 				throw new IllegalStateException("Client " + client + " was not added or is already removed");
@@ -1134,7 +1170,13 @@ public class InputService extends AccessibilityService {
 	 * tap for surfaces that do not expose a clickable accessibility node.
 	 */
 	private void clickAtCoordinates(InputContext inputContext, int x, int y) {
-		if (!performAccessibleClickAt(inputContext.getDisplayId(), x, y)) {
+		boolean handledByAccessibilityNode = performAccessibleClickAt(inputContext.getDisplayId(), x, y);
+		if (BuildConfig.DEBUG) {
+			Log.d(TAG, "clickAtCoordinates: " + x + "," + y
+					+ " display=" + inputContext.getDisplayId()
+					+ " nodeHandled=" + handledByAccessibilityNode);
+		}
+		if (!handledByAccessibilityNode) {
 			mMainHandler.post(() ->
 					dispatchGesture(
 							createClick(inputContext, x, y, Math.max(1, ViewConfiguration.getTapTimeout())),


### PR DESCRIPTION
## Summary

- distinguish a pointer tap from a drag before dispatching an accessibility gesture
- click the deepest clickable accessibility node at the pointer coordinates, with a standalone tap gesture as fallback
- preserve per-client input state when Android rebinds the accessibility service
- detach and recreate service-owned pointer overlays across a rebind
- queue keyboard and pointer packets that arrive while the service is reconnecting

## Root cause

The pointer-down handler set `isButtonOneDown` and then immediately evaluated a second independent condition that treated the same packet as an already-active stroke. This could dispatch a zero-length continued gesture before the release packet arrived.

Some Android TV builds also do not route injected tap gestures to application controls consistently. When the target is represented in the accessibility tree, invoking `ACTION_CLICK` on the deepest clickable node is more reliable.

On the tested Fire OS device, Android destroyed and reconnected the accessibility service while the VNC client remained connected. Because the client map belonged to the old service instance, later input packets either lost their context or arrived while no service instance was available.

## Validation

- `gradlew testDebugUnitTest assembleDebug`
- tested an APK built from current `master` plus these two commits on an Amazon Signage Stick running Android 11-based Fire OS
- tested with 1920x1080 Android output and a scaled 960x540 VNC framebuffer
- sent a raw RFB pointer click at framebuffer coordinate `638,158`, mapped to Android coordinate `1276,316`
- verified an accessible WebView checkbox changed from checked to unchecked
- verified the click succeeded while logs showed `InputService.onDestroy` followed by `InputService.onServiceConnected` during the VNC session

Related to #244 and #347.

## AI assistance disclosure

This diagnosis and implementation were developed with assistance from OpenAI Codex. Codex helped inspect the input path, propose and implement the changes, build the raw RFB regression harness, and draft this pull request. Elier Herrera directed the work, reviewed the contribution scope, and validated the result on the physical device.
