### PR TITLE
Extend text selection on Shift+navigation over VNC (API 34+)

### DIFF
--- a/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
+++ b/app/src/main/java/net/christianbeier/droidvnc_ng/InputService.java
@@ -227,7 +227,11 @@ public class InputService extends AccessibilityService {
 			// send any text selection over to the client as cut text
 			if (event.getEventType() == AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED
 					&& Objects.requireNonNull(event.getSource()).getTextSelectionStart() != event.getSource().getTextSelectionEnd()) {
-				CharSequence selection = event.getSource().getText().subSequence(event.getSource().getTextSelectionStart(), event.getSource().getTextSelectionEnd());
+				// #385: a backwards selection (e.g. Shift+Left) reports start > end, so clamp with
+				// min/max -- subSequence(start, end) would otherwise throw StringIndexOutOfBounds.
+				int selStart = event.getSource().getTextSelectionStart();
+				int selEnd = event.getSource().getTextSelectionEnd();
+				CharSequence selection = event.getSource().getText().subSequence(Math.min(selStart, selEnd), Math.max(selStart, selEnd));
 				MainService.vncSendCutText(selection.toString());
 			}
 		} catch (Exception e) {
@@ -544,6 +548,11 @@ public class InputService extends AccessibilityService {
 					if (keysym == 0xffff) keyCode = KeyEvent.KEYCODE_FORWARD_DEL;
 					// Insert
 					if (keysym == 0xff63) keyCode = KeyEvent.KEYCODE_INSERT;
+					// Shift: deliver as a real modifier key so the editor's MetaKeyKeyListener tracks
+					// it as held, which is what makes Shift+navigation extend the text selection (#385).
+					// Without this the Shift keysym maps to KEYCODE_UNKNOWN and the held state is lost.
+					if (keysym == 0xffe1) keyCode = KeyEvent.KEYCODE_SHIFT_LEFT;
+					if (keysym == 0xffe2) keyCode = KeyEvent.KEYCODE_SHIFT_RIGHT;
 					// Enter
 					if (keysym == 0xff0d) keyCode = KeyEvent.KEYCODE_ENTER;
 					// Tab


### PR DESCRIPTION
Fixes #385.

## Problem
On the API 34+ `InputConnection.sendKeyEvent()` path, a Shift held on the VNC
client was dropped: `XK_Shift_L/R` (0xffe1/0xffe2) map to `KEYCODE_UNKNOWN`, so
the editor's `MetaKeyKeyListener` never saw Shift held. Shift+arrow and
Shift+PageUp/PageDown therefore only moved the caret instead of extending the
text selection.

Setting `META_SHIFT_ON` on the navigation `KeyEvent` alone does **not** fix it
— I tried that first and the editor still just moved the caret. The editor
tracks the modifier from a real key down/up, not from the arrow event's meta
state.

## Fix
- Map `XK_Shift_L/R` → `KEYCODE_SHIFT_LEFT/RIGHT` so they are delivered as real
  modifier key events. The held state is then tracked and the navigation keys
  extend/shrink the selection, just like a locally attached keyboard.
- Once selection works, a backwards selection (e.g. Shift+Left) reports
  `start > end`, which made the selection→cut-text handler call
  `subSequence(start, end)` and throw `StringIndexOutOfBoundsException` (it was
  caught, but it broke the client-clipboard mirror for leftward selections and
  spammed the log). Clamp the bounds with `min`/`max`.

Scope is deliberately limited to Shift (the case in #385). Ctrl/Alt keysyms are
left unchanged. Home/End are intentionally left out here because they are
currently bound to global actions (a separate topic).

## Testing
Built from this branch and tested on **Android 14** over VNC on a real device
(the InputConnection path):
- Shift+Left/Right extend and shrink the selection with a fixed anchor —
  verified in logcat via `TYPE_VIEW_TEXT_SELECTION_CHANGED` reporting
  start ≠ end (both forward and backward).
- Shift+PageUp/PageDown select to start/end of the field.
- Backwards selections no longer throw `StringIndexOutOfBoundsException`.
- Plain (no-Shift) arrows still just move the caret — no regression.
