### PR TITLE
CI: run on JDK 21 to fix the lintVitalAnalyzeRelease NoSuchMethodError

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: 'true'
-    - name: set up JDK 17
+    - name: set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: gradle
     - name: Assemble Release Build


### PR DESCRIPTION
As diagnosed in #387: the Kotlin/PSI analysis engine bundled with the current AGP's lint uses `java.util.List.removeLast()`, a JDK 21+ (SequencedCollection) API, so `:app:lintVitalAnalyzeRelease` crashes with `NoSuchMethodError` on the JDK 17 runner and every PR build has been red since mid-August. Bumping the workflow to JDK 21 fixes it; the same builds already pass locally on a JDK 21+ runtime.

Fixes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)