### PR TITLE
ui: show default Max. reconnect tries #275

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you want to accept incoming connections from VNC viewers:
 Here's how to connect to a listening VNC viewer or repeater without opening a server port:
 1. Leave the VNC port **blank**, which will get the Admin Panel to state the server **isn't** listening for incoming connections.
 2. Make outbound connections by choosing either "Connect to a **listening viewer**" or "Connect to a **repeater**".
-3. Optionally fill **Max. reconnect tries**. If you leave it empty, they are set from the default or from the intent.
+3. Optionally fill **Max. reconnect tries**. If you leave it empty, the default is **0** (no reconnect), unless a reverse/repeater [intent](doc/Intent-Interface.md) set `EXTRA_RECONNECT_TRIES`.
 
 
 ### How to Pre-seed Preferences

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you want to accept incoming connections from VNC viewers:
 Here's how to connect to a listening VNC viewer or repeater without opening a server port:
 1. Leave the VNC port **blank**, which will get the Admin Panel to state the server **isn't** listening for incoming connections.
 2. Make outbound connections by choosing either "Connect to a **listening viewer**" or "Connect to a **repeater**".
-3. Optionally fill **Max. reconnect tries**. If you leave it empty, the default is **0** (no reconnect).
+3. Optionally fill **Max. reconnect tries**. If you leave it empty, reconnect tries are not set.
 
 
 ### How to Pre-seed Preferences

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ If you want to accept incoming connections from VNC viewers:
 Here's how to connect to a listening VNC viewer or repeater without opening a server port:
 1. Leave the VNC port **blank**, which will get the Admin Panel to state the server **isn't** listening for incoming connections.
 2. Make outbound connections by choosing either "Connect to a **listening viewer**" or "Connect to a **repeater**".
+3. Optionally fill **Max. reconnect tries**. If you leave it empty, the default is **0** (no reconnect).
 
 
 ### How to Pre-seed Preferences

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you want to accept incoming connections from VNC viewers:
 Here's how to connect to a listening VNC viewer or repeater without opening a server port:
 1. Leave the VNC port **blank**, which will get the Admin Panel to state the server **isn't** listening for incoming connections.
 2. Make outbound connections by choosing either "Connect to a **listening viewer**" or "Connect to a **repeater**".
-3. Optionally fill **Max. reconnect tries**. If you leave it empty, reconnect tries are not set.
+3. Optionally fill **Max. reconnect tries**. If you leave it empty, they are set from the default or from the intent.
 
 
 ### How to Pre-seed Preferences

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you want to accept incoming connections from VNC viewers:
 Here's how to connect to a listening VNC viewer or repeater without opening a server port:
 1. Leave the VNC port **blank**, which will get the Admin Panel to state the server **isn't** listening for incoming connections.
 2. Make outbound connections by choosing either "Connect to a **listening viewer**" or "Connect to a **repeater**".
-3. Optionally fill **Max. reconnect tries**. If you leave it empty, the default is **0** (no reconnect), unless a reverse/repeater [intent](doc/Intent-Interface.md) set `EXTRA_RECONNECT_TRIES`.
+3. Optionally fill **Max. reconnect tries**. If you leave it empty, the default is **0** (no reconnect). Connections started from the [Intent Interface](doc/Intent-Interface.md) can set `EXTRA_RECONNECT_TRIES` instead.
 
 
 ### How to Pre-seed Preferences

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
     <string name="main_activity_repeater_vnc_success">Connection to %1$s with ID %2$s succeeded</string>
     <string name="main_activity_repeater_vnc_fail">Connection to %1$s with ID %2$s failed</string>
     <string name="main_activity_repeater_vnc_input_missing">Host and/or ID missing</string>
-    <string name="main_activity_reconnect_tries_hint">Max. reconnect tries (default 0)</string>
+    <string name="main_activity_reconnect_tries_hint">Max. reconnect tries</string>
     <string name="main_activity_special_key_reference">From a VNC viewer, the keyboard shortcuts assigned above trigger their Android actions.</string>
     <string name="main_activity_settings_key_shortcuts">Keyboard Shortcuts</string>
     <string name="main_activity_settings_key_shortcuts_button">Configure</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
     <string name="main_activity_repeater_vnc_success">Connection to %1$s with ID %2$s succeeded</string>
     <string name="main_activity_repeater_vnc_fail">Connection to %1$s with ID %2$s failed</string>
     <string name="main_activity_repeater_vnc_input_missing">Host and/or ID missing</string>
-    <string name="main_activity_reconnect_tries_hint">Max. reconnect tries</string>
+    <string name="main_activity_reconnect_tries_hint">Max. reconnect tries (default 0)</string>
     <string name="main_activity_special_key_reference">From a VNC viewer, the keyboard shortcuts assigned above trigger their Android actions.</string>
     <string name="main_activity_settings_key_shortcuts">Keyboard Shortcuts</string>
     <string name="main_activity_settings_key_shortcuts_button">Configure</string>


### PR DESCRIPTION
The reverse/repeater dialogs let you leave Max. reconnect tries empty, but the field and README did not say what that means.

Empty now shows as default 0 in the placeholder, and Reverse VNC in the README says 0 means no reconnect.

Closes #275